### PR TITLE
Possible fix for ZEN-9497

### DIFF
--- a/txwinrm/request/create.xml
+++ b/txwinrm/request/create.xml
@@ -11,7 +11,7 @@
         <w:Locale xml:lang="en-US" s:mustUnderstand="false" />
         <p:DataLocale xml:lang="en-US" s:mustUnderstand="false" />
         <w:OptionSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-            <w:Option Name="WINRS_NOPROFILE">TRUE</w:Option>
+            <w:Option Name="WINRS_NOPROFILE">FALSE</w:Option>
             <w:Option Name="WINRS_CODEPAGE">437</w:Option>
         </w:OptionSet>
         <w:OperationTimeout>PT60.000S</w:OperationTimeout>


### PR DESCRIPTION
User reported a fix for performance counter localization on the wiki page.  Changing WINRS_PROFILE to false, installing english language, and setting the monitor user to use english as a language fixed his problem.  We will test out using the profile.  Not sure why it was taken out in the first place so we'll need to let QA run some tests.