### PR TITLE
Feature/zen 20175

### DIFF
--- a/txwinrm/app.py
+++ b/txwinrm/app.py
@@ -170,15 +170,15 @@ def _parse_config_file(filename, utility):
     parser = RawConfigParser(allow_no_value=True)
     parser.read(filename)
     creds = {}
-    index = dict(authentication=0, username=1)
+    index = dict(authentication=0, username=1, password=2)
     for key, value in parser.items('credentials'):
         k1, k2 = key.split('.')
         if k1 not in creds:
             creds[k1] = [None, None, None]
         creds[k1][index[k2]] = value
-        if k2 == 'username':
-            creds[k1][2] = getpass('{0} password ({1} credentials):'
-                                   .format(value, k1))
+    if not creds[k1][2]:
+        creds[k1][2] = getpass('{0} password ({1} credentials):'
+                               .format(value, k1))
     conn_infos = []
     for remote, cred_key in parser.items('remotes'):
         auth_type, username, password = creds[cred_key]

--- a/txwinrm/app.py
+++ b/txwinrm/app.py
@@ -217,6 +217,7 @@ def _parse_args(utility):
     parser.add_argument("--username", "-u")
     parser.add_argument("--dcip", "-i")
     parser.add_argument("--keytab", "-k")
+    parser.add_argument("--password", "-p")
     utility.add_args(parser)
     args = parser.parse_args()
     if not args.config:
@@ -228,7 +229,9 @@ def _parse_args(utility):
             sys.exit(1)
         if args.remote:
             hostname, scheme, port = _parse_remote(args.remote)
-            password = getpass()
+            password = args.password
+            if not password:
+                password = getpass()
             connectiontype = 'Keep-Alive'
             args.conn_info = ConnectionInfo(
                 hostname, args.authentication, args.username, password, scheme,


### PR DESCRIPTION
Allow for password to be supplied on the command line and in config.  This can then be used by zaas to send service restart commands via dc-admin