### PR TITLE
Feature/zen 22558

### DIFF
--- a/txwinrm/enumerate.py
+++ b/txwinrm/enumerate.py
@@ -88,16 +88,15 @@ class WinrmClient(object):
                 request_template_name = 'pull'
             else:
                 raise Exception("Reached max requests per enumeration.")
-        except ResponseFailed as e:
-            for reason in e.reasons:
-                log.error('{0} {1}'.format(self._hostname, reason.value))
+        except (ResponseFailed, RequestError, Exception) as e:
+            yield self._sender.close_connections()
+            if isinstance(e, ResponseFailed):
+                for reason in e.reasons:
+                    log.error('{0} {1}'.format(self._hostname, reason.value))
+            else:
+                log.debug('{0} {1}'.format(self._hostname, e))
             raise
-        except RequestError as e:
-            log.debug('{0} {1}'.format(self._hostname, e))
-            raise
-        except Exception as e:
-            log.error('{0} {1}'.format(self._hostname, e))
-            raise
+        yield self._sender.close_connections()
         defer.returnValue(items)
 
 

--- a/txwinrm/shell.py
+++ b/txwinrm/shell.py
@@ -121,6 +121,7 @@ class SingleShotCommand(object):
         shell_id = yield self._create_shell()
         cmd_response = yield self._run_command(shell_id, command_line)
         yield self._delete_shell(shell_id)
+        yield self._sender.close_connections()
         defer.returnValue(cmd_response)
 
     @defer.inlineCallbacks
@@ -184,7 +185,7 @@ class LongRunningCommand(object):
         command_line_elem = _build_command_line_elem(command_line)
         log.debug('LongRunningCommand run_command: sending command request '
                   '(shell_id={0}, command_line_elem={1})'.format(
-                  self._shell_id, command_line_elem))
+                    self._shell_id, command_line_elem))
         command_elem = yield self._sender.send_request(
             'command', shell_id=self._shell_id,
             command_line_elem=command_line_elem,
@@ -218,6 +219,7 @@ class LongRunningCommand(object):
             command_id=self._command_id,
             signal_code=c.SHELL_SIGNAL_TERMINATE)
         yield self._sender.send_request('delete', shell_id=self._shell_id)
+        yield self._sender.close_connections()
         defer.returnValue(CommandResponse(stdout, stderr, self._exit_code))
 
 
@@ -348,7 +350,7 @@ class RemoteShell(object):
         command_line_elem = _build_command_line_elem('cmd')
         log.debug('RemoteShell create: sending command request (shell_id={0}, '
                   'command_line_elem={1})'.format(
-                  self._shell_id, command_line_elem))
+                    self._shell_id, command_line_elem))
         command_elem = yield self._sender.send_request(
             'command', shell_id=self._shell_id,
             command_line_elem=command_line_elem,

--- a/txwinrm/util.py
+++ b/txwinrm/util.py
@@ -588,16 +588,14 @@ class RequestSender(object):
         # close connections
         # return a Deferred()
         if self.agent and hasattr(self.agent, 'closeCachedConnections'):
-            # twisted 11
-            d = defer.Deferred()
-            d.callback(self.agent.closeCachedConnections())
-            return d
+            # twisted 11 has no return and is part of the Agent
+            return defer.succeed(self.agent.closeCachedConnections())
         elif self.agent:
-            # twisted 12
+            # twisted 12 returns a Deferred
             return self.agent.pool.closeCachedConnections()
         else:
             # no agent
-            return defer.Deferred()
+            return defer.succeed(None)
 
 
 class _StringProtocol(Protocol):


### PR DESCRIPTION
We should go ahead and close connections after collection.  Waiting for twisted to close them when the Agent is destroyed can take several minutes, which leaves established connections that stick around and are never removed, resulting in several connections/open files until the system runs out of open files.

Packet capture from customer showed this happening.  After data is received, no FIN is sent to close the socket.  After about 2 minutes a RST is sent from the Windows server.  The socket stays alive but is never closed.