### PR TITLE
don't close connection for these errors

### DIFF
--- a/txwinrm/enumerate.py
+++ b/txwinrm/enumerate.py
@@ -89,7 +89,6 @@ class WinrmClient(object):
             else:
                 raise Exception("Reached max requests per enumeration.")
         except (ResponseFailed, RequestError, Exception) as e:
-            yield self._sender.close_connections()
             if isinstance(e, ResponseFailed):
                 for reason in e.reasons:
                     log.error('{0} {1}'.format(self._hostname, reason.value))


### PR DESCRIPTION
Fixes ZEN-22558

ResponseFailed/RequestErrors are ok to receive, no need to close
connections.  Doing this caused a hiccup in the last exception
caught to show an ImportError for pysamba.twisted.reactor.