### PR TITLE
Send request to ip address instead of fqdn

### DIFF
--- a/txwinrm/app.py
+++ b/txwinrm/app.py
@@ -9,7 +9,6 @@
 
 import sys
 import logging
-import socket
 from getpass import getpass
 from urlparse import urlparse
 from argparse import ArgumentParser
@@ -234,8 +233,6 @@ def _parse_args(utility):
             password = args.password
             if not password:
                 password = getpass()
-            if not args.ipaddress:
-                args.ipaddress = socket.gethostbyname(hostname)
             connectiontype = 'Keep-Alive'
             args.conn_info = ConnectionInfo(
                 hostname, args.authentication, args.username, password, scheme,

--- a/txwinrm/app.py
+++ b/txwinrm/app.py
@@ -9,6 +9,7 @@
 
 import sys
 import logging
+import socket
 from getpass import getpass
 from urlparse import urlparse
 from argparse import ArgumentParser
@@ -218,6 +219,7 @@ def _parse_args(utility):
     parser.add_argument("--dcip", "-i")
     parser.add_argument("--keytab", "-k")
     parser.add_argument("--password", "-p")
+    parser.add_argument("--ipaddress", "-s")
     utility.add_args(parser)
     args = parser.parse_args()
     if not args.config:
@@ -232,10 +234,12 @@ def _parse_args(utility):
             password = args.password
             if not password:
                 password = getpass()
+            if not args.ipaddress:
+                args.ipaddress = socket.gethostbyname(hostname)
             connectiontype = 'Keep-Alive'
             args.conn_info = ConnectionInfo(
                 hostname, args.authentication, args.username, password, scheme,
-                port, connectiontype, args.keytab, args.dcip)
+                port, connectiontype, args.keytab, args.dcip, ipaddress=args.ipaddress)
             try:
                 verify_conn_info(args.conn_info)
             except Exception as e:

--- a/txwinrm/util.py
+++ b/txwinrm/util.py
@@ -403,20 +403,27 @@ class ConnectionInfo(namedtuple(
         'dcip',
         'timeout',
         'trusted_realm',
-        'trusted_kdc'])):
+        'trusted_kdc',
+        'ipaddress'])):
     def __new__(cls, hostname, auth_type, username, password, scheme, port,
-                connectiontype, keytab, dcip, timeout=60, trusted_realm='', trusted_kdc=''):
+                connectiontype, keytab, dcip, timeout=60, trusted_realm='', trusted_kdc='', ipaddress=''):
         return super(ConnectionInfo, cls).__new__(cls, hostname, auth_type,
                                                   username, password, scheme,
                                                   port, connectiontype, keytab,
                                                   dcip, timeout,
-                                                  trusted_realm, trusted_kdc)
+                                                  trusted_realm, trusted_kdc, ipaddress)
 
 
 def verify_hostname(conn_info):
     has_hostname, hostname = _has_get_attr(conn_info, 'hostname')
     if not has_hostname or not hostname:
         raise Exception("hostname is not resolvable")
+
+
+def verify_ipaddress(conn_info):
+    has_ipaddress, ipaddress = _has_get_attr(conn_info, 'ipaddress')
+    if not has_ipaddress or not ipaddress:
+        raise Exception("ipaddress missing")
 
 
 def verify_auth_type(conn_info):
@@ -457,6 +464,7 @@ def verify_connectiontype(conn_info):
     if not has_connectiontype or not connectiontype:
         raise Exception("connectiontype missing")
 
+
 def verify_timeout(conn_info):
     has_timeout, timeout = _has_get_attr(conn_info, 'timeout')
     if not has_timeout:
@@ -464,8 +472,10 @@ def verify_timeout(conn_info):
     if not timeout:
         conn_info.timeout = 60
 
+
 def verify_conn_info(conn_info):
     verify_hostname(conn_info)
+    verify_ipaddress(conn_info)
     verify_auth_type(conn_info)
     verify_username(conn_info)
     verify_password(conn_info)
@@ -488,7 +498,7 @@ class RequestSender(object):
 
     @defer.inlineCallbacks
     def _get_url_and_headers(self):
-        url = "{c.scheme}://{c.hostname}:{c.port}/wsman".format(c=self._conn_info)
+        url = "{c.scheme}://{c.ipaddress}:{c.port}/wsman".format(c=self._conn_info)
         if self._conn_info.auth_type == 'basic':
             headers = Headers(_CONTENT_TYPE)
             headers.addRawHeader('Connection', self._conn_info.connectiontype)

--- a/txwinrm/util.py
+++ b/txwinrm/util.py
@@ -407,6 +407,8 @@ class ConnectionInfo(namedtuple(
         'ipaddress'])):
     def __new__(cls, hostname, auth_type, username, password, scheme, port,
                 connectiontype, keytab, dcip, timeout=60, trusted_realm='', trusted_kdc='', ipaddress=''):
+        if not ipaddress:
+            ipaddress = hostname
         return super(ConnectionInfo, cls).__new__(cls, hostname, auth_type,
                                                   username, password, scheme,
                                                   port, connectiontype, keytab,


### PR DESCRIPTION
Fixes ZEN-22880

This change negates the need for DNS lookup in twisted when sending
a request to a Windows server.  It should both speed up requests
and allow for devices with no name resolution to be contacted.
Also added the --ipaddress,-s switch to winrm/winrs to enter
the ip address of the device.