### PR TITLE
Add classes to support sending commands through single connection

### DIFF
--- a/txwinrm/SessionManager.py
+++ b/txwinrm/SessionManager.py
@@ -1,0 +1,205 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""txsessionmgr - Python module for a single persistent connection to a device
+for multiple clients.
+
+Useful for situations when multiple connections to a device can be handled
+with one connection through a single login, e.g. txciscoapic, txwinrm
+
+The global SESSION_MANAGER is instantiated one time and is used to manage
+all sessions
+
+Session should be subclassed and implemented to login/logout, send requests,
+and handle responses
+
+A Client should always have a key property.  This will be unique to the types
+of transactions/requests being made through a single Session
+
+"""
+
+from twisted.internet.defer import inlineCallbacks, returnValue, succeed
+
+
+class Session(object):
+    """
+    Session handler for connection to a device.
+
+    deferred_init will kick off a deferred login to a device from the first
+    client that needs the connection.  Subsequent clients will use the data
+    returned from the first login.
+
+    The Session class is responsible for implementing the login/logout methods
+    """
+    def __init__(self):
+        # Used to keep track of clients using session
+        self._clients = set()
+
+        # The currently valid token.  This can be anything that the client
+        # needs to know the connection is alive
+        self._token = None
+
+        # Deferred waiting for login result.
+        self._login_d = None
+
+        # Error from last login if applicable.
+        self._login_error = None
+
+        # Deferred sending a refresh/keep-alive signal/request
+        self._refresh_d = None
+
+    @inlineCallbacks
+    def deferred_login(self, client):
+        """Return Deferred token
+
+        :param client: Client initiating a connection
+        :client: ZenPack specific client
+        :rtype: Deferred
+        :return: Returns ZenPack unique token to be used for a session.
+        """
+        self._clients.add(client)
+        if self._token:
+            returnValue(self._token)
+
+        # No one already waiting for a token. Login to get a new one.
+        if not self._login_d or self._login_d.called:
+            self._login_d = self._deferred_login(client)
+
+            try:
+                self._token = yield self._login_d
+            except Exception as e:
+                self._login_error = e
+                raise
+
+        # At least one other client is already waiting for a token, and
+        # the login to get it is already in progress. Wait for that
+        # login to finish, then return its token.
+        else:
+            yield self._login_d
+            if self._login_error:
+                raise self._login_error
+
+        returnValue(self._token)
+
+    @inlineCallbacks
+    def deferred_logout(self, client):
+        """Return Deferred None.
+
+        Calls session._deferred_logout() only if all other clients using the same
+        session have also called deferred_logout.
+
+        """
+        if len(self._clients) <= 1:
+            if self._token:
+                try:
+                    yield self._deferred_logout()
+                except Exception:
+                    pass
+
+            self._token = None
+
+        if client in self._clients:
+            self._clients.remove(client)
+        returnValue(None)
+
+    @inlineCallbacks
+    def _deferred_login(self, client):
+        '''login method
+
+        Performs the ZenPack specific login to a device.  This will only be called
+        from the first client to fire off the deferred.  All other clients will
+        use the _token returned from this method
+
+        :param client: Client initiating a connection
+        :type client: ZenPack specific client
+        :rtype: Deferred
+        :return: Returns a Deferred which is logs into the device.
+        '''
+        returnValue(None)
+
+    @inlineCallbacks
+    def _deferred_logout(self):
+        '''logout method
+
+        Performs the ZenPack specific logout from a device.  This will only be called
+        by the last client to logout of the session.
+
+        :rtype: Deferred
+        :return: Returns a Deferred which logs out of the device
+        '''
+        returnValue(None)
+
+
+class SessionManager(object):
+    '''
+    Class to manage open sessions to devices.
+    '''
+    def __init__(self):
+        # Used to keep track of sessions
+        self._sessions = {}
+
+    def get_connection(self, key):
+        '''Return the session for a given key
+        '''
+        if key is None:
+            raise Exception('Client key cannot be empty')
+        return self._sessions.get(key, None)
+
+    def remove_connection(self, key):
+        session = self.get_connection(key)
+        if session:
+            self._sessions.pop(session)
+
+    @inlineCallbacks
+    def init_connection(self, client, session_class=Session):
+        '''Initialize connection to device.
+        If a session is already started return it.
+        Else kick off deferred to initiate session
+
+        The client must contain a key for session storage
+
+        :param client: Client initiating connection
+        :client: ZenPack defined client.
+        '''
+        if not hasattr(client, 'key'):
+            raise Exception('Client must contain a key field')
+
+        session = self.get_connection(client.key)
+        if session:
+            if session._token:
+                if client not in session._clients:
+                    session._clients.add(client)
+                returnValue(session._token)
+
+        if session is None:
+            session = session_class()
+            self._sessions[client.key] = session
+
+        token = yield session.deferred_login(client)
+        returnValue(token)
+
+    @inlineCallbacks
+    def close_connection(self, client):
+        '''Kick off a session's logout
+        If there are no more clients using a session, remove it
+
+        :param client:  Client closing connection
+        :client: ZenPack defined class
+        '''
+        session = self.get_connection(client.key)
+        if not session:
+            returnValue(None)
+        yield session.deferred_logout(client)
+        if not session._clients:
+            # no more clients so we don't need to keep the session
+            self._sessions.pop(client.key)
+        returnValue(None)
+
+
+SESSION_MANAGER = SessionManager()

--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -96,6 +96,9 @@ class WinRMSession(Session):
     def is_kerberos(self):
         return self._conn_info.auth_type == 'kerberos'
 
+    def decrypt_body(self, body):
+        return self._gssclient.decrypt_body(body)
+
     def _set_headers(self):
         if self._headers:
             return self._headers
@@ -248,6 +251,9 @@ class WinRMClient(object):
 
     def is_kerberos(self):
         return self._conn_info.auth_type == 'kerberos'
+
+    def decrypt_body(self, body):
+        return self._session.decrypt_body(body)
 
     @inlineCallbacks
     def _create_shell(self):
@@ -432,9 +438,7 @@ class EnumerateClient(WinRMClient):
         """
         Runs a remote WQL query.
         """
-        if self._session is None:
-            yield self.session_manager.init_connection(self, WinRMSession)
-            self._session = self.session_manager.get_connection(self.key)
+        self.init_connection()
         request_template_name = 'enumerate'
         enumeration_context = None
         items = []

--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -1,0 +1,492 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2013, all rights reserved.
+#
+# This content is made available according to terms specified in the LICENSE
+# file at the top-level directory of this package.
+#
+##############################################################################
+
+import logging
+from httplib import BAD_REQUEST, UNAUTHORIZED, FORBIDDEN, OK
+
+from twisted.internet.defer import (
+    inlineCallbacks,
+    returnValue,
+    DeferredSemaphore,
+    succeed
+)
+from twisted.internet.error import TimeoutError
+
+try:
+    from twisted.web.client import ResponseFailed
+    ResponseFailed
+except ImportError:
+    class ResponseFailed(Exception):
+        pass
+
+from . import constants as c
+from kerberos import GSSError
+from .util import (
+    _authenticate_with_kerberos,
+    _get_agent,
+    verify_conn_info,
+    _CONTENT_TYPE,
+    _ENCRYPTED_CONTENT_TYPE,
+    Headers,
+    _get_basic_auth_header,
+    _get_request_template,
+    _StringProducer,
+    get_auth_details,
+    UnauthorizedError,
+    ForbiddenError,
+    RequestError,
+    _ErrorReader,
+    _StringProtocol,
+    ET
+)
+from .shell import (
+    _find_shell_id,
+    _build_command_line_elem,
+    _find_command_id,
+    _MAX_REQUESTS_PER_COMMAND,
+    _find_stream,
+    _find_exit_code,
+    CommandResponse,
+    _stripped_lines
+)
+from .enumerate import (
+    DEFAULT_RESOURCE_URI,
+    SaxResponseHandler,
+    _MAX_REQUESTS_PER_ENUMERATION
+)
+from .SessionManager import SESSION_MANAGER, Session
+LOG = logging.getLogger('winrm')
+
+
+class WinRMSession(Session):
+    '''
+    Session class to keep track of single winrm connection
+
+
+    '''
+    def __init__(self):
+        super(WinRMSession, self).__init__()
+
+        # twisted agent to send http/https requests
+        self._agent = _get_agent()
+
+        # our kerberos context for encryption/decryption
+        self._gssclient = None
+
+        # url for session
+        self._url = None
+
+        # headers to use for requests
+        self._headers = None
+
+        # connection info.  see util.ConnectionInfo
+        self._conn_info = None
+
+        # DeferredSemaphore so that we complete one transaction/conversation
+        # at a time.  Windows cannot handle mixed transaction types on one
+        # connection.
+        self.sem = DeferredSemaphore(1)
+
+    def is_kerberos(self):
+        return self._conn_info.auth_type == 'kerberos'
+
+    def _set_headers(self):
+        if self._headers:
+            return self._headers
+        if self._conn_info.auth_type == 'basic':
+            self._headers = Headers(_CONTENT_TYPE)
+            self._headers.addRawHeader('Connection', self._conn_info.connectiontype)
+            self._headers.addRawHeader(
+                'Authorization', _get_basic_auth_header(self._conn_info))
+        elif self.is_kerberos():
+            self._headers = Headers(_ENCRYPTED_CONTENT_TYPE)
+            self._headers.addRawHeader('Connection', self._conn_info.connectiontype)
+        return self._headers
+
+    @inlineCallbacks
+    def _deferred_login(self, client=None):
+        if client:
+            self._conn_info = client._conn_info
+        self._url = "{c.scheme}://{c.ipaddress}:{c.port}/wsman".format(c=self._conn_info)
+        if self.is_kerberos():
+            self._gssclient = yield _authenticate_with_kerberos(self._conn_info, self._url, self._agent)
+            returnValue(self._gssclient)
+        else:
+            returnValue('basic_auth_token')
+
+    @inlineCallbacks
+    def _deferred_logout(self):
+        # close connections so we do not end up with orphans
+        # return a Deferred()
+        self.loggedout = True
+        if self._agent and hasattr(self._agent, 'closeCachedConnections'):
+            # twisted 11 has no return and is part of the Agent
+            return succeed(self._agent.closeCachedConnections())
+        elif self._agent:
+            # twisted 12 returns a Deferred
+            return self._agent._pool.closeCachedConnections()
+        else:
+            # no agent
+            return succeed(None)
+
+    @inlineCallbacks
+    def handle_response(self, request, response, client):
+        if response.code == UNAUTHORIZED or response.code == BAD_REQUEST:
+            # check to see if we need to re-authorize due to lost connection or bad request error
+            if self._gssclient is not None:
+                self._gssclient.cleanup()
+                self._gssclient = None
+                self._token = None
+                self._agent = _get_agent()
+                self._login_d = None
+                yield SESSION_MANAGER.init_connection(client, WinRMSession)
+                try:
+                    yield self._set_headers()
+                    encrypted_request = self._gssclient.encrypt_body(request)
+                    if not encrypted_request.startswith("--Encrypted Boundary"):
+                        self._headers.setRawHeaders('Content-Type', _CONTENT_TYPE['Content-Type'])
+                    body_producer = _StringProducer(encrypted_request)
+                    response = yield self._agent.request(
+                        'POST', self._url, self._headers, body_producer)
+                except Exception as e:
+                    raise e
+            if response.code == UNAUTHORIZED:
+                if self.is_kerberos():
+                    auth_header = response.headers.getRawHeaders('WWW-Authenticate')[0]
+                    auth_details = get_auth_details(auth_header)
+                    try:
+                        if auth_details:
+                            self._gssclient._step(auth_details)
+                    except GSSError as e:
+                        msg = "HTTP Unauthorized received.  "
+                        "Kerberos error code {0}: {1}.".format(e.args[1][1], e.args[1][0])
+                        raise Exception(msg)
+                raise UnauthorizedError(
+                    "HTTP Unauthorized received: Check username and password")
+        if response.code == FORBIDDEN:
+            raise ForbiddenError(
+                "Forbidden: Check WinRM port and version")
+        elif response.code != OK:
+            if self.is_kerberos():
+                reader = _ErrorReader(self._gssclient)
+            else:
+                reader = _ErrorReader()
+            response.deliverBody(reader)
+            message = yield reader.d
+            raise RequestError("HTTP status: {}. {}".format(
+                response.code, message))
+        returnValue(response)
+
+    @inlineCallbacks
+    def send_request(self, request_template_name, client, **kwargs):
+        response = yield self._send_request(
+            request_template_name, client, **kwargs)
+        proto = _StringProtocol()
+        response.deliverBody(proto)
+        body = yield proto.d
+        if self.is_kerberos():
+            xml_str = self._gssclient.decrypt_body(body)
+        else:
+            xml_str = yield body
+        if LOG.isEnabledFor(logging.DEBUG):
+            try:
+                import xml.dom.minidom
+                xml = xml.dom.minidom.parseString(xml_str)
+                LOG.debug(xml.toprettyxml())
+            except:
+                LOG.debug('Could not prettify response XML: "{0}"'.format(xml_str))
+        returnValue(ET.fromstring(xml_str))
+
+    @inlineCallbacks
+    def _send_request(self, request_template_name, client, **kwargs):
+        if self._login_d and not self._login_d.called:
+            # check for a reconnection attempt so we do not send any requests
+            # to a dead connection
+            yield self._login_d
+        LOG.debug('sending request: {0} {1}'.format(
+            request_template_name, kwargs))
+        request = _get_request_template(request_template_name).format(**kwargs)
+        self._headers = self._set_headers()
+        if self.is_kerberos():
+            encrypted_request = self._gssclient.encrypt_body(request)
+            if not encrypted_request.startswith("--Encrypted Boundary"):
+                self._headers.setRawHeaders('Content-Type', _CONTENT_TYPE['Content-Type'])
+            body_producer = _StringProducer(encrypted_request)
+        else:
+            body_producer = _StringProducer(request)
+        try:
+            response = yield self._agent.request(
+                'POST', self._url, self._headers, body_producer)
+        except Exception as e:
+            raise e
+        LOG.debug('received response {0} {1}'.format(
+            response.code, request_template_name))
+        response = yield self.handle_response(request, response, client)
+        returnValue(response)
+
+
+class WinRMClient(object):
+    def __init__(self, conn_info):
+        verify_conn_info(conn_info)
+        self.key = None
+        self._conn_info = conn_info
+        self.session_manager = SESSION_MANAGER
+        self._session = None
+
+    @inlineCallbacks
+    def init_connection(self):
+        '''Initialize a connection through the session_manager'''
+        yield self.session_manager.init_connection(self, WinRMSession)
+        self._session = self.session_manager.get_connection(self.key)
+        returnValue(None)
+
+    def is_kerberos(self):
+        return self._conn_info.auth_type == 'kerberos'
+
+    @inlineCallbacks
+    def _create_shell(self):
+        elem = yield self._session.send_request('create', self)
+        returnValue(_find_shell_id(elem))
+
+    @inlineCallbacks
+    def _delete_shell(self, shell_id):
+        yield self._session.send_request('delete', self, shell_id=shell_id)
+        returnValue(None)
+
+    @inlineCallbacks
+    def _signal_terminate(self, shell_id, command_id):
+        yield self._session.send_request('signal',
+                                         self,
+                                         shell_id=shell_id,
+                                         command_id=command_id,
+                                         signal_code=c.SHELL_SIGNAL_TERMINATE)
+        returnValue(None)
+
+    @inlineCallbacks
+    def _signal_ctrl_c(self, shell_id, command_id):
+        yield self._session.send_request('signal',
+                                         self,
+                                         shell_id=shell_id,
+                                         command_id=command_id,
+                                         signal_code=c.SHELL_SIGNAL_CTRL_C)
+        returnValue(None)
+
+    @inlineCallbacks
+    def _send_command(self, shell_id, command_line):
+        command_line_elem = _build_command_line_elem(command_line)
+        command_elem = yield self._session.send_request(
+            'command', self, shell_id=shell_id, command_line_elem=command_line_elem,
+            timeout=self._conn_info.timeout)
+        returnValue(command_elem)
+
+    @inlineCallbacks
+    def _send_receive(self, shell_id, command_id):
+        receive_elem = yield self._session.send_request(
+            'receive', self, shell_id=shell_id, command_id=command_id)
+        returnValue(receive_elem)
+
+    @inlineCallbacks
+    def close_connection(self):
+        yield self.session_manager.close_connection(self)
+        returnValue(None)
+
+
+class SingleCommandClient(WinRMClient):
+
+    def __init__(self, conn_info):
+        super(SingleCommandClient, self).__init__(conn_info)
+        self.key = (self._conn_info.ipaddress, 'short')
+
+    @inlineCallbacks
+    def run_command(self, command_line):
+        '''
+        Run a single command in the session's semaphore.  Windows must finish
+        a command conversation before a new command or enumeration can start
+        '''
+        yield self.init_connection()
+        try:
+            cmd_response = yield self._session.sem.run(self.run_single_command,
+                                                       command_line)
+        except Exception:
+            self.close_connection()
+        returnValue(cmd_response)
+
+    @inlineCallbacks
+    def run_single_command(self, command_line):
+        """
+        Run a single command line in a remote shell like the winrs application
+        on Windows. Returns a dictionary with the following
+        structure:
+            CommandResponse
+                .stdout = [<non-empty, stripped line>, ...]
+                .stderr = [<non-empty, stripped line>, ...]
+                .exit_code = <int>
+        """
+        shell_id = yield self._create_shell()
+
+        try:
+            cmd_response = yield self._run_command(shell_id, command_line)
+        except TimeoutError:
+            yield self.close_connection()
+        yield self._delete_shell(shell_id)
+        yield self.close_connection()
+        returnValue(cmd_response)
+
+    @inlineCallbacks
+    def _run_command(self, shell_id, command_line):
+        command_elem = yield self._send_command(shell_id, command_line)
+        command_id = _find_command_id(command_elem)
+        stdout_parts = []
+        stderr_parts = []
+        for i in xrange(_MAX_REQUESTS_PER_COMMAND):
+            receive_elem = yield self._send_receive(shell_id, command_id)
+            stdout_parts.extend(
+                _find_stream(receive_elem, command_id, 'stdout'))
+            stderr_parts.extend(
+                _find_stream(receive_elem, command_id, 'stderr'))
+            exit_code = _find_exit_code(receive_elem, command_id)
+            if exit_code is not None:
+                break
+        else:
+            raise Exception("Reached max requests per command.")
+        yield self._signal_terminate(shell_id, command_id)
+        stdout = _stripped_lines(stdout_parts)
+        stderr = _stripped_lines(stderr_parts)
+        returnValue(CommandResponse(stdout, stderr, exit_code))
+
+
+class LongCommandClient(WinRMClient):
+    def __init__(self, conn_info):
+        super(LongCommandClient, self).__init__(conn_info)
+        self._shell_id = None
+        self._command_id = None
+        self._exit_code = None
+
+    @inlineCallbacks
+    def start(self, command_line):
+        LOG.debug("LongRunningCommand run_command: {0}".format(command_line))
+        self.key = (self._conn_info.ipaddress, command_line)
+        yield self.init_connection()
+        self._shell_id = yield self._create_shell()
+        command_line_elem = _build_command_line_elem(command_line)
+        LOG.debug('LongRunningCommand run_command: sending command request '
+                  '(shell_id={0}, command_line_elem={1})'.format(
+                      self._shell_id, command_line_elem))
+        try:
+            command_elem = yield self._send_command(self._shell_id,
+                                                    command_line)
+        except TimeoutError:
+            yield self.session_manager.close_connection(self)
+            raise
+        self._command_id = _find_command_id(command_elem)
+        returnValue(None)
+
+    @inlineCallbacks
+    def receive(self):
+        try:
+            receive_elem = yield self._send_receive(self._shell_id, self._command_id)
+        except TimeoutError:
+            yield self.session_manager.close_connection(self)
+            raise
+        stdout_parts = _find_stream(receive_elem, self._command_id, 'stdout')
+        stderr_parts = _find_stream(receive_elem, self._command_id, 'stderr')
+        self._exit_code = _find_exit_code(receive_elem, self._command_id)
+        stdout = _stripped_lines(stdout_parts)
+        stderr = _stripped_lines(stderr_parts)
+        returnValue((stdout, stderr))
+
+    @inlineCallbacks
+    def stop(self, close=False):
+        yield self._signal_ctrl_c(self._shell_id, self._command_id)
+        try:
+            stdout, stderr = yield self.receive()
+        except TimeoutError:
+            pass
+        yield self._signal_terminate(self._shell_id, self._command_id)
+        yield self._delete_shell(self._shell_id)
+        if close:
+            self.session_manager.close_connection(self)
+        returnValue(CommandResponse(stdout, stderr, self._exit_code))
+
+
+class EnumerateClient(WinRMClient):
+    """
+    Sends enumerate requests to a host running the WinRM service and returns
+    a list of items.
+    """
+
+    def __init__(self, conn_info):
+        super(EnumerateClient, self).__init__(conn_info)
+        self._handler = SaxResponseHandler(self)
+        self._hostname = conn_info.ipaddress
+        self.key = (conn_info.ipaddress, 'short')
+
+    @inlineCallbacks
+    def enumerate(self, wql, resource_uri=DEFAULT_RESOURCE_URI):
+        """
+        Runs a remote WQL query.
+        """
+        if self._session is None:
+            yield self.session_manager.init_connection(self, WinRMSession)
+            self._session = self.session_manager.get_connection(self.key)
+        request_template_name = 'enumerate'
+        enumeration_context = None
+        items = []
+        try:
+            for i in xrange(_MAX_REQUESTS_PER_ENUMERATION):
+                LOG.info('{0} "{1}" {2}'.format(
+                    self._hostname, wql, request_template_name))
+                response = yield self._session._send_request(
+                    request_template_name,
+                    self,
+                    resource_uri=resource_uri,
+                    wql=wql,
+                    enumeration_context=enumeration_context)
+                LOG.info("{0} {1} HTTP status: {2}".format(
+                    self._hostname, wql, response.code))
+                enumeration_context, new_items = \
+                    yield self._handler.handle_response(response)
+                items.extend(new_items)
+                if not enumeration_context:
+                    break
+                request_template_name = 'pull'
+            else:
+                raise Exception("Reached max requests per enumeration.")
+        except (ResponseFailed, RequestError, Exception) as e:
+            if isinstance(e, ResponseFailed):
+                for reason in e.reasons:
+                    LOG.error('{0} {1}'.format(self._hostname, reason.value))
+            else:
+                LOG.info('{0} {1}'.format(self._hostname, e))
+            raise
+        returnValue(items)
+
+    @inlineCallbacks
+    def do_collect(self, enum_infos):
+        '''
+        Run enumerations in the session's semaphore.  Windows must finish
+        an enumeration before a new command or enumeration can start
+        '''
+        items = {}
+        yield self.init_connection()
+        self._session = self.session_manager.get_connection(self.key)
+        for enum_info in enum_infos:
+            try:
+                items[enum_info] = yield self._session.sem.run(self.enumerate,
+                                                               enum_info.wql,
+                                                               enum_info.resource_uri)
+            except (UnauthorizedError, ForbiddenError):
+                # Fail the collection for general errors.
+                raise
+            except RequestError:
+                # Store empty results for other query-specific errors.
+                continue
+
+        yield self.close_connection()
+        returnValue(items)

--- a/txwinrm/app.py
+++ b/txwinrm/app.py
@@ -219,6 +219,7 @@ def _parse_args(utility):
     parser.add_argument("--keytab", "-k")
     parser.add_argument("--password", "-p")
     parser.add_argument("--ipaddress", "-s")
+    parser.add_argument("--service", "-e", help='http/https/wsman', default='http')
     utility.add_args(parser)
     args = parser.parse_args()
     if not args.config:
@@ -235,8 +236,10 @@ def _parse_args(utility):
                 password = getpass()
             connectiontype = 'Keep-Alive'
             args.conn_info = ConnectionInfo(
-                hostname, args.authentication, args.username, password, scheme,
-                port, connectiontype, args.keytab, args.dcip, ipaddress=args.ipaddress)
+                hostname, args.authentication,
+                args.username, password, scheme,
+                port, connectiontype, args.keytab,
+                args.dcip, ipaddress=args.ipaddress, service=args.service)
             try:
                 verify_conn_info(args.conn_info)
             except Exception as e:

--- a/txwinrm/shell.py
+++ b/txwinrm/shell.py
@@ -181,10 +181,6 @@ class LongRunningCommand(object):
         self._command_id = None
         self._exit_code = None
 
-    def __del__(self):
-        # in case of network errors
-        yield self._sender.close_connections()
-
     @defer.inlineCallbacks
     def start(self, command_line):
         log.debug("LongRunningCommand run_command: {0}".format(command_line))
@@ -239,7 +235,6 @@ class LongRunningCommand(object):
             command_id=self._command_id,
             signal_code=c.SHELL_SIGNAL_TERMINATE)
         yield self._sender.send_request('delete', shell_id=self._shell_id)
-        yield self._sender.close_connections()
         defer.returnValue(CommandResponse(stdout, stderr, self._exit_code))
 
 

--- a/txwinrm/winrm.py
+++ b/txwinrm/winrm.py
@@ -14,7 +14,7 @@ Use twisted web client to enumerate/pull WQL query.
 import sys
 from twisted.internet import defer
 from . import app
-from .enumerate import create_winrm_client
+from .WinRMClient import EnumerateClient
 
 
 class WinrmStrategy(object):
@@ -49,7 +49,7 @@ class WinrmStrategy(object):
         include_header = len(config.conn_infos) > 1
         ds = []
         for conn_info in good_conn_infos:
-            client = create_winrm_client(conn_info)
+            client = EnumerateClient(conn_info)
             for wql in config.wqls:
                 d = client.enumerate(wql)
                 d.addCallback(


### PR DESCRIPTION
Fixes ZEN-24477

This adds SessionManager to manage single connections to a device to
cut down on DNS lookups for kerberos.  it will also allow for using a
single connection to run enumerations and single commands.  Because of
Windows limitations, conversations must be completed before a new
operation can start.  So all single commands and enumerations will
have to run sequentially.  Long running commands will need their own
connection.  Changed cli app to use the new clients.

Also, added support for using the WSMAN service principal name