### PR TITLE
Add AssociatorClient for 'Associators of' WQL query

### DIFF
--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -495,3 +495,81 @@ class EnumerateClient(WinRMClient):
 
         yield self.close_connection()
         returnValue(items)
+
+
+class AssociatorClient(EnumerateClient):
+
+    """
+        WinRM Client that can return wmi classes that are associated with
+        another wmi class through a single property.
+        First a regular wmi query is run to select objects from a class.
+            e.g. 'select * from Win32_NetworkAdapter'
+        Next we will loop through the results and run the associator query
+        using a specific property of the object as input to return
+        a result class.
+            e.g. for interface in interfaces:
+                "ASSOCIATORS OF {Win32_NetworkAdapter.DeviceID=interface.DeviceID} WHERE ResultClass=Win32_PnPEntity'
+    """
+
+    @inlineCallbacks
+    def associate(self,
+                  seed_class,
+                  associations,
+                  where=None,
+                  resource_uri=DEFAULT_RESOURCE_URI,
+                  fields=['*']):
+        """Method to retrieve associated wmi classes based upon a
+        property from a given class
+
+        seed_class - wmi class which will be initially queried
+        associations - list of dicts containing parameters for
+            the 'ASSOCIATORS of {A}' wql statement.  We dequeue the
+            dicts and can search results from previous wql query to
+            search for nested associations.
+                search_class - initial class to associate with
+                search_property - property on search_class to match
+                return_class - class which will be returned
+                where_type - keyword of association type:
+                    AssocClass = AssocClassName
+                    RequiredAssocQualifier = QualifierName
+                    RequiredQualifier = QualifierName
+                    ResultClass = ClassName
+                    ResultRole = PropertyName
+                    Role = PropertyName
+        where - wql where clause to narrow scope of initial query
+        resource_uri - uri of resource.  this will be the same for both
+            input and result classes.  Limitation of WQL
+        fields - fields to return from seed_class on initial query
+
+        returns dict of seed_class and all return_class results
+
+        see https://msdn.microsoft.com/en-us/library/aa384793(v=vs.85).aspx
+        """
+        items = {}
+        wql = 'Select {} from {}'.format(','.join(fields), seed_class)
+        if where:
+            wql += ' where {}'.format(where)
+        input_results = yield self.enumerate(wql, resource_uri)
+
+        items[seed_class] = input_results
+        while associations:
+            association = associations.pop(0)
+            associate_results = []
+            for item in input_results:
+                try:
+                    prop = getattr(item, association['search_property'])
+                except AttributeError:
+                    continue
+                else:
+                    wql = "ASSOCIATORS of {{{}.{}='{}'}} WHERE {}={}".format(
+                        association['search_class'],
+                        association['search_property'],
+                        prop,
+                        association['where_type'],
+                        association['return_class'])
+                    result = yield self.enumerate(wql, resource_uri)
+                    associate_results.extend(result)
+
+            items[association['return_class']] = associate_results
+            input_results = associate_results
+        returnValue(items)

--- a/txwinrm/associate.py
+++ b/txwinrm/associate.py
@@ -1,0 +1,97 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2013, all rights reserved.
+#
+# This content is made available according to terms specified in the LICENSE
+# file at the top-level directory of this package.
+#
+##############################################################################
+
+import logging
+
+from twisted.internet import defer
+from WinRMClient import AssociatorClient
+from .util import (
+    ConnectionInfo,
+)
+
+log = logging.getLogger('winrm')
+# for use with seed_class of Win32_NetworkAdapter
+interface_map = [{'return_class': 'Win32_PnPEntity',
+                  'search_class': 'win32_NetworkAdapter',
+                  'search_property': 'DeviceID',
+                  'where_type': 'ResultClass'
+                  }]
+# for use with seed_class of Win32_DiskDrive
+disk_map = [{'return_class': 'Win32_DiskDriveToDiskPartition',
+             'search_class': 'Win32_DiskDrive',
+             'search_property': 'DeviceID',
+             'where_type': 'AssocClass'},
+            {'return_class': 'Win32_LogicalDiskToPartition',
+             'search_class': 'Win32_DiskPartition',
+             'search_property': 'DeviceID',
+             'where_type': 'AssocClass'
+             }]
+
+
+class WinrmAssociatorClient(object):
+
+    @defer.inlineCallbacks
+    def do_associate(self, conn_info):
+        """
+        """
+        client = AssociatorClient(conn_info)
+        items = {}
+
+        items = yield client.associate(
+            'Win32_DiskDrive',
+            disk_map
+        )
+
+        defer.returnValue(items)
+
+
+# ----- An example of usage...
+
+if __name__ == '__main__':
+    from pprint import pprint
+    import logging
+    from twisted.internet import reactor
+    logging.basicConfig()
+    winrm = WinrmAssociatorClient()
+
+    # Enter your params here before running
+    params = {
+        'hostname': "",  # name of host
+        'authtype': "",  # kerberos or basic
+        'user': "",  # username
+        'password': "",  # password
+        'kdc': "",  # kdc address
+        'ipaddress': ""  # ip address
+    }
+
+    ''' Remove this line and line at the end to run test
+    @defer.inlineCallbacks
+    def do_example_collect():
+        connectiontype = 'Keep-Alive'
+        conn_info = ConnectionInfo(
+            params['hostname'],
+            params['authtype'],
+            params['user'],
+            params['password'],
+            "http",
+            5985,
+            connectiontype,
+            "",
+            params['kdc'],
+            ipaddress=params['ipaddress'])
+
+        items = yield winrm.do_associate(conn_info)
+        pprint(items)
+        pprint(items.keys())
+        reactor.stop()
+
+    reactor.callWhenRunning(do_example_collect)
+    reactor.run()
+
+    Remove this line to execute above code'''


### PR DESCRIPTION
Fixes ZPS-479

First part of update for Windows Hard Disk component.  We'll need
to use the 'associators of' query to map hard disks and file systems.
This will also be useful for other plugins, interfaces and iis.

Allow for nested association calls, update test script