### PR TITLE
Allow for user to specify envelope size in requests

### DIFF
--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -193,6 +193,8 @@ class WinRMSession(Session):
 
     @inlineCallbacks
     def send_request(self, request_template_name, client, **kwargs):
+        if 'envelope_size' not in kwargs.keys():
+            kwargs['envelope_size'] = client._conn_info.envelope_size
         response = yield self._send_request(
             request_template_name, client, **kwargs)
         proto = _StringProtocol()
@@ -213,6 +215,8 @@ class WinRMSession(Session):
 
     @inlineCallbacks
     def _send_request(self, request_template_name, client, **kwargs):
+        if 'envelope_size' not in kwargs.keys():
+            kwargs['envelope_size'] = client._conn_info.envelope_size
         if self._login_d and not self._login_d.called:
             # check for a reconnection attempt so we do not send any requests
             # to a dead connection

--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -192,11 +192,9 @@ class WinRMSession(Session):
         returnValue(response)
 
     @inlineCallbacks
-    def send_request(self, request_template_name, client, **kwargs):
-        if 'envelope_size' not in kwargs.keys():
-            kwargs['envelope_size'] = client._conn_info.envelope_size
+    def send_request(self, request_template_name, client, envelope_size=None, **kwargs):
         response = yield self._send_request(
-            request_template_name, client, **kwargs)
+            request_template_name, client, envelope_size=envelope_size, **kwargs)
         proto = _StringProtocol()
         response.deliverBody(proto)
         body = yield proto.d
@@ -214,9 +212,8 @@ class WinRMSession(Session):
         returnValue(ET.fromstring(xml_str))
 
     @inlineCallbacks
-    def _send_request(self, request_template_name, client, **kwargs):
-        if 'envelope_size' not in kwargs.keys():
-            kwargs['envelope_size'] = client._conn_info.envelope_size
+    def _send_request(self, request_template_name, client, envelope_size=None, **kwargs):
+        kwargs['envelope_size'] = envelope_size or client._conn_info.envelope_size
         if self._login_d and not self._login_d.called:
             # check for a reconnection attempt so we do not send any requests
             # to a dead connection

--- a/txwinrm/enumerate.py
+++ b/txwinrm/enumerate.py
@@ -244,7 +244,7 @@ class ParserFeedingProtocol(Protocol):
             try:
                 self._xml_parser.feed(data)
             except Exception:
-                log.debug('Could not parse data {}'.format(data))
+                raise Exception('Could not parse SOAP message: {}'.format(data))
         if self._debug_data and log.isEnabledFor(logging.DEBUG):
             try:
                 import xml.dom.minidom

--- a/txwinrm/enumerate.py
+++ b/txwinrm/enumerate.py
@@ -216,7 +216,7 @@ class ParserFeedingProtocol(Protocol):
         self.d = defer.Deferred()
         self._debug_data = ''
         self._sender = sender
-        self._data = [] 
+        self._data = []
 
     def dataReceived(self, data):
         """
@@ -241,13 +241,16 @@ class ParserFeedingProtocol(Protocol):
             #  Decrypt data first
             data = self._sender.decrypt_body(''.join(self._data))
             self._debug_data = data
-            self._xml_parser.feed(data)
+            try:
+                self._xml_parser.feed(data)
+            except Exception:
+                log.debug('Could not parse data {}'.format(data))
         if self._debug_data and log.isEnabledFor(logging.DEBUG):
             try:
                 import xml.dom.minidom
                 xml = xml.dom.minidom.parseString(self._debug_data)
                 log.debug(xml.toprettyxml())
-            except:
+            except Exception:
                 log.debug('Could not prettify response XML: "{0}"'
                           .format(self._debug_data))
         if isinstance(reason.value, ResponseFailed):

--- a/txwinrm/request/command.xml
+++ b/txwinrm/request/command.xml
@@ -6,7 +6,7 @@
             <a:Address s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
         </a:ReplyTo>
         <a:Action s:mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command</a:Action>
-        <w:MaxEnvelopeSize s:mustUnderstand="true">153600</w:MaxEnvelopeSize>
+        <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:799002D6-F3D9-4CAF-968F-D2802410148F</a:MessageID>
         <w:Locale xml:lang="en-US" s:mustUnderstand="false" />
         <p:DataLocale xml:lang="en-US" s:mustUnderstand="false" />

--- a/txwinrm/request/create.xml
+++ b/txwinrm/request/create.xml
@@ -6,7 +6,7 @@
             <a:Address s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
         </a:ReplyTo>
         <a:Action s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/Create</a:Action>
-        <w:MaxEnvelopeSize s:mustUnderstand="true">153600</w:MaxEnvelopeSize>
+        <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:D515053B-134D-4B63-9DA9-6FA9C520A6B4</a:MessageID>
         <w:Locale xml:lang="en-US" s:mustUnderstand="false" />
         <p:DataLocale xml:lang="en-US" s:mustUnderstand="false" />

--- a/txwinrm/request/delete.xml
+++ b/txwinrm/request/delete.xml
@@ -5,7 +5,7 @@
             <a:Address s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
         </a:ReplyTo>
         <a:Action s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete</a:Action>
-        <w:MaxEnvelopeSize s:mustUnderstand="true">153600</w:MaxEnvelopeSize>
+        <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:EEA0F479-EC1D-4908-BAAF-B023103E5DDB</a:MessageID>
         <w:Locale xml:lang="en-US" s:mustUnderstand="false" />
         <p:DataLocale xml:lang="en-US" s:mustUnderstand="false" />

--- a/txwinrm/request/enumerate.xml
+++ b/txwinrm/request/enumerate.xml
@@ -6,7 +6,7 @@
             <a:Address s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
         </a:ReplyTo>
         <a:Action s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/Enumerate</a:Action>
-        <w:MaxEnvelopeSize s:mustUnderstand="true">512000</w:MaxEnvelopeSize>
+        <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:55F28C75-F63E-4F68-8360-A8C478003959</a:MessageID>
         <w:OperationTimeout>PT60.000S</w:OperationTimeout>
     </s:Header>

--- a/txwinrm/request/event_pull.xml
+++ b/txwinrm/request/event_pull.xml
@@ -6,7 +6,7 @@
             <a:Address s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
         </a:ReplyTo>
         <a:Action s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/Pull</a:Action>
-        <w:MaxEnvelopeSize s:mustUnderstand="true">153600</w:MaxEnvelopeSize>
+        <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:DC17922E-EBE7-4333-B92A-7157EB372F33</a:MessageID>
         <w:Locale s:mustUnderstand="false" xml:lang="en-US"/>
         <p:DataLocale s:mustUnderstand="false" xml:lang="en-US"/>

--- a/txwinrm/request/pull.xml
+++ b/txwinrm/request/pull.xml
@@ -6,7 +6,7 @@
             <a:Address s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
         </a:ReplyTo>
         <a:Action s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/Pull</a:Action>
-        <w:MaxEnvelopeSize s:mustUnderstand="true">512000</w:MaxEnvelopeSize>
+        <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:578DC055-B6C4-4387-B39F-E992D0ED76A0</a:MessageID>
         <w:OperationTimeout>PT60.000S</w:OperationTimeout>
     </s:Header>

--- a/txwinrm/request/receive.xml
+++ b/txwinrm/request/receive.xml
@@ -5,7 +5,7 @@
             <a:Address s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
         </a:ReplyTo>
         <a:Action s:mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive</a:Action>
-        <w:MaxEnvelopeSize s:mustUnderstand="true">153600</w:MaxEnvelopeSize>
+        <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:D40A0940-F00D-4E7A-9DB2-D668853DC958</a:MessageID>
         <w:Locale xml:lang="en-US" s:mustUnderstand="false" />
         <p:DataLocale xml:lang="en-US" s:mustUnderstand="false" />

--- a/txwinrm/request/send.xml
+++ b/txwinrm/request/send.xml
@@ -5,7 +5,7 @@
             <a:Address s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
         </a:ReplyTo>
         <a:Action s:mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Send</a:Action>
-        <w:MaxEnvelopeSize s:mustUnderstand="true">153600</w:MaxEnvelopeSize>
+        <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:5F28DC8E-A7AA-46F0-8AAC-727C1CF85D1B</a:MessageID>
         <w:Locale s:mustUnderstand="false" xml:lang="en-US"/>
         <p:DataLocale s:mustUnderstand="false" xml:lang="en-US"/>

--- a/txwinrm/request/signal.xml
+++ b/txwinrm/request/signal.xml
@@ -5,7 +5,7 @@
             <a:Address s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
         </a:ReplyTo>
         <a:Action s:mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Signal</a:Action>
-        <w:MaxEnvelopeSize s:mustUnderstand="true">153600</w:MaxEnvelopeSize>
+        <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:9EE2148F-83C8-462E-8323-0B46F34951CE</a:MessageID>
         <w:Locale xml:lang="en-US" s:mustUnderstand="false" />
         <p:DataLocale xml:lang="en-US" s:mustUnderstand="false" />

--- a/txwinrm/request/subscribe.xml
+++ b/txwinrm/request/subscribe.xml
@@ -6,7 +6,7 @@
             <a:Address s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
         </a:ReplyTo>
         <a:Action s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/eventing/Subscribe</a:Action>
-        <w:MaxEnvelopeSize s:mustUnderstand="true">153600</w:MaxEnvelopeSize>
+        <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:40E5E215-9AE6-4BB2-BF59-5BE542B6E67B</a:MessageID>
         <w:Locale s:mustUnderstand="false" xml:lang="en-US"/>
         <p:DataLocale s:mustUnderstand="false" xml:lang="en-US"/>

--- a/txwinrm/request/unsubscribe.xml
+++ b/txwinrm/request/unsubscribe.xml
@@ -5,7 +5,7 @@
             <a:Address s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
         </a:ReplyTo>
         <a:Action s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/eventing/Unsubscribe</a:Action>
-        <w:MaxEnvelopeSize s:mustUnderstand="true">153600</w:MaxEnvelopeSize>
+        <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:2A0865D5-CA69-4CEC-A9BB-CAAF455DF2AE</a:MessageID>
         <w:Locale s:mustUnderstand="false" xml:lang="en-US"/>
         <p:DataLocale s:mustUnderstand="false" xml:lang="en-US"/>

--- a/txwinrm/util.py
+++ b/txwinrm/util.py
@@ -417,9 +417,11 @@ class ConnectionInfo(namedtuple(
         'trusted_realm',
         'trusted_kdc',
         'ipaddress',
-        'service'])):
+        'service',
+        'envelope_size'])):
     def __new__(cls, hostname, auth_type, username, password, scheme, port,
-                connectiontype, keytab, dcip, timeout=60, trusted_realm='', trusted_kdc='', ipaddress='', service=''):
+                connectiontype, keytab, dcip, timeout=60, trusted_realm='',
+                trusted_kdc='', ipaddress='', service='', envelope_size=512000):
         if not ipaddress:
             ipaddress = hostname
         if not service:
@@ -428,7 +430,8 @@ class ConnectionInfo(namedtuple(
                                                   username, password, scheme,
                                                   port, connectiontype, keytab,
                                                   dcip, timeout,
-                                                  trusted_realm, trusted_kdc, ipaddress, service)
+                                                  trusted_realm, trusted_kdc, ipaddress, service,
+                                                  envelope_size)
 
 
 def verify_hostname(conn_info):


### PR DESCRIPTION
Fixes ZPS-82

* User can supply envelope size if set to larger in Windows
* Catch exception when parsing xml