### PR TITLE
Add support for winrm localization

### DIFF
--- a/txwinrm/request/command.xml
+++ b/txwinrm/request/command.xml
@@ -8,8 +8,8 @@
         <a:Action s:mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command</a:Action>
         <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:799002D6-F3D9-4CAF-968F-D2802410148F</a:MessageID>
-        <w:Locale xml:lang="en-US" s:mustUnderstand="false" />
-        <p:DataLocale xml:lang="en-US" s:mustUnderstand="false" />
+        <w:Locale xml:lang="{locale}" s:mustUnderstand="false" />
+        <p:DataLocale xml:lang="{locale}" s:mustUnderstand="false" />
         <w:SelectorSet>
             <w:Selector Name="ShellId">{shell_id}</w:Selector>
         </w:SelectorSet>

--- a/txwinrm/request/create.xml
+++ b/txwinrm/request/create.xml
@@ -8,11 +8,11 @@
         <a:Action s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/Create</a:Action>
         <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:D515053B-134D-4B63-9DA9-6FA9C520A6B4</a:MessageID>
-        <w:Locale xml:lang="en-US" s:mustUnderstand="false" />
-        <p:DataLocale xml:lang="en-US" s:mustUnderstand="false" />
+        <w:Locale xml:lang="{locale}" s:mustUnderstand="false" />
+        <p:DataLocale xml:lang="{locale}" s:mustUnderstand="false" />
         <w:OptionSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <w:Option Name="WINRS_NOPROFILE">FALSE</w:Option>
-            <w:Option Name="WINRS_CODEPAGE">437</w:Option>
+            <w:Option Name="WINRS_CODEPAGE">{code_page}</w:Option>
         </w:OptionSet>
         <w:OperationTimeout>PT60.000S</w:OperationTimeout>
     </s:Header>

--- a/txwinrm/request/delete.xml
+++ b/txwinrm/request/delete.xml
@@ -7,8 +7,8 @@
         <a:Action s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete</a:Action>
         <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:EEA0F479-EC1D-4908-BAAF-B023103E5DDB</a:MessageID>
-        <w:Locale xml:lang="en-US" s:mustUnderstand="false" />
-        <p:DataLocale xml:lang="en-US" s:mustUnderstand="false" />
+        <w:Locale xml:lang="{locale}" s:mustUnderstand="false" />
+        <p:DataLocale xml:lang="{locale}" s:mustUnderstand="false" />
         <w:ResourceURI xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</w:ResourceURI>
         <w:SelectorSet xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">
             <w:Selector Name="ShellId">{shell_id}</w:Selector>

--- a/txwinrm/request/event_pull.xml
+++ b/txwinrm/request/event_pull.xml
@@ -8,8 +8,8 @@
         <a:Action s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/Pull</a:Action>
         <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:DC17922E-EBE7-4333-B92A-7157EB372F33</a:MessageID>
-        <w:Locale s:mustUnderstand="false" xml:lang="en-US"/>
-        <p:DataLocale s:mustUnderstand="false" xml:lang="en-US"/>
+        <w:Locale s:mustUnderstand="false" xml:lang="{locale}"/>
+        <p:DataLocale s:mustUnderstand="false" xml:lang="{locale}"/>
         <w:OptionSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <w:Option Name="SubscriptionName">ZenossSubscription</w:Option>
             <w:Option Name="ContentFormat">RenderedText</w:Option>

--- a/txwinrm/request/receive.xml
+++ b/txwinrm/request/receive.xml
@@ -7,8 +7,8 @@
         <a:Action s:mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive</a:Action>
         <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:D40A0940-F00D-4E7A-9DB2-D668853DC958</a:MessageID>
-        <w:Locale xml:lang="en-US" s:mustUnderstand="false" />
-        <p:DataLocale xml:lang="en-US" s:mustUnderstand="false" />
+        <w:Locale xml:lang="{locale}" s:mustUnderstand="false" />
+        <p:DataLocale xml:lang="{locale}" s:mustUnderstand="false" />
         <w:ResourceURI xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</w:ResourceURI>
         <w:SelectorSet xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">
             <w:Selector Name="ShellId">{shell_id}</w:Selector>

--- a/txwinrm/request/send.xml
+++ b/txwinrm/request/send.xml
@@ -7,8 +7,8 @@
         <a:Action s:mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Send</a:Action>
         <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:5F28DC8E-A7AA-46F0-8AAC-727C1CF85D1B</a:MessageID>
-        <w:Locale s:mustUnderstand="false" xml:lang="en-US"/>
-        <p:DataLocale s:mustUnderstand="false" xml:lang="en-US"/>
+        <w:Locale s:mustUnderstand="false" xml:lang="{locale}"/>
+        <p:DataLocale s:mustUnderstand="false" xml:lang="{locale}"/>
         <w:ResourceURI xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</w:ResourceURI>
         <w:SelectorSet xmlns="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">
             <w:Selector Name="ShellId">{shell_id}</w:Selector>

--- a/txwinrm/request/signal.xml
+++ b/txwinrm/request/signal.xml
@@ -7,8 +7,8 @@
         <a:Action s:mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Signal</a:Action>
         <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:9EE2148F-83C8-462E-8323-0B46F34951CE</a:MessageID>
-        <w:Locale xml:lang="en-US" s:mustUnderstand="false" />
-        <p:DataLocale xml:lang="en-US" s:mustUnderstand="false" />
+        <w:Locale xml:lang="{locale}" s:mustUnderstand="false" />
+        <p:DataLocale xml:lang="{locale}" s:mustUnderstand="false" />
         <w:ResourceURI xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</w:ResourceURI>
         <w:SelectorSet xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">
             <w:Selector Name="ShellId">{shell_id}</w:Selector>

--- a/txwinrm/request/subscribe.xml
+++ b/txwinrm/request/subscribe.xml
@@ -8,8 +8,8 @@
         <a:Action s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/eventing/Subscribe</a:Action>
         <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:40E5E215-9AE6-4BB2-BF59-5BE542B6E67B</a:MessageID>
-        <w:Locale s:mustUnderstand="false" xml:lang="en-US"/>
-        <p:DataLocale s:mustUnderstand="false" xml:lang="en-US"/>
+        <w:Locale s:mustUnderstand="false" xml:lang="{locale}"/>
+        <p:DataLocale s:mustUnderstand="false" xml:lang="{locale}"/>
         <w:OptionSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <w:Option Name="SubscriptionName">ZenossSubscription</w:Option>
             <w:Option Name="ContentFormat">RenderedText</w:Option>

--- a/txwinrm/request/unsubscribe.xml
+++ b/txwinrm/request/unsubscribe.xml
@@ -7,8 +7,8 @@
         <a:Action s:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/eventing/Unsubscribe</a:Action>
         <w:MaxEnvelopeSize s:mustUnderstand="true">{envelope_size}</w:MaxEnvelopeSize>
         <a:MessageID>uuid:2A0865D5-CA69-4CEC-A9BB-CAAF455DF2AE</a:MessageID>
-        <w:Locale s:mustUnderstand="false" xml:lang="en-US"/>
-        <p:DataLocale s:mustUnderstand="false" xml:lang="en-US"/>
+        <w:Locale s:mustUnderstand="false" xml:lang="{locale}"/>
+        <p:DataLocale s:mustUnderstand="false" xml:lang="{locale}"/>
         <w:OptionSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <w:Option Name="SubscriptionName">ZenossSubscription</w:Option>
             <w:Option Name="ContentFormat">RenderedText</w:Option>

--- a/txwinrm/shell.py
+++ b/txwinrm/shell.py
@@ -49,7 +49,7 @@ class CommandResponse(object):
             stdout=self.stdout, stderr=self.stderr, exit_code=self.exit_code))
 
 
-def _build_command_line_elem(command_line):
+def _build_command_line_elem(command_line, encoding='utf-8'):
     command_line_parts = shlex.split(command_line, posix=False)
     prefix = "rsp"
     ET.register_namespace(prefix, c.XML_NS_MSRSP)
@@ -63,7 +63,7 @@ def _build_command_line_elem(command_line):
         command_line_elem.append(arguments_elem)
     tree = ET.ElementTree(command_line_elem)
     str_io = StringIO()
-    tree.write(str_io)
+    tree.write(str_io, encoding=encoding)
     return str_io.getvalue()
 
 

--- a/txwinrm/util.py
+++ b/txwinrm/util.py
@@ -418,10 +418,14 @@ class ConnectionInfo(namedtuple(
         'trusted_kdc',
         'ipaddress',
         'service',
-        'envelope_size'])):
+        'envelope_size',
+        'code_page',
+        'encoding',
+        'locale'])):
     def __new__(cls, hostname, auth_type, username, password, scheme, port,
                 connectiontype, keytab, dcip, timeout=60, trusted_realm='',
-                trusted_kdc='', ipaddress='', service='', envelope_size=512000):
+                trusted_kdc='', ipaddress='', service='', envelope_size=512000,
+                code_page=65001, encoding='utf-8', locale='en-US'):
         if not ipaddress:
             ipaddress = hostname
         if not service:
@@ -430,8 +434,22 @@ class ConnectionInfo(namedtuple(
                                                   username, password, scheme,
                                                   port, connectiontype, keytab,
                                                   dcip, timeout,
-                                                  trusted_realm, trusted_kdc, ipaddress, service,
-                                                  envelope_size)
+                                                  trusted_realm, trusted_kdc,
+                                                  ipaddress, service,
+                                                  envelope_size, code_page,
+                                                  encoding, locale)
+
+
+def verify_code_page(conn_info):
+    has_code_page, code_page = _has_get_attr(conn_info, 'code_page')
+    if not has_code_page or not isinstance(code_page, int):
+        raise Exception("code_page must be an integer")
+
+
+def verify_envelope_size(conn_info):
+    has_envelope_size, envelope_size = _has_get_attr(conn_info, 'envelope_size')
+    if not has_envelope_size or not isinstance(envelope_size, int):
+        raise Exception("envelope_size must be an integer")
 
 
 def verify_hostname(conn_info):


### PR DESCRIPTION
Fixes ZPS-554

* Allow user supplied code page, default to 65001
* Allow user supplied locale, default to en-US
* Allow user supplied encoding, default to utf-8
* Added function to build powershell command line.  shlex splits
  the script itself into separate arguments when it should be just
  one.  SingleCommandClient and LongCommandClient will accept the
  powershell command line with options along with the script in a
  separate parameter, ps_script