### PR TITLE
SingleCommandClient should raise exceptions when run_command fails

### DIFF
--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -401,6 +401,7 @@ class SingleCommandClient(WinRMClient):
                                                        command_line)
         except Exception:
             yield self.close_connection()
+            raise
         returnValue(cmd_response)
 
     @inlineCallbacks


### PR DESCRIPTION
Since run_command currently suppresses exceptions, these do not get
picked up downstream and cannot be handled by PythonCollector onError
methods used by ShellDatasource, etc