### PR TITLE
Only set rdns option when specifically told to disable it

### DIFF
--- a/txwinrm/app.py
+++ b/txwinrm/app.py
@@ -221,7 +221,7 @@ def _parse_args(utility):
     parser.add_argument("--ipaddress", "-s")
     parser.add_argument("--service", "-e", help='http/https/wsman', default='http')
     parser.add_argument("--includedir", help="valid includedir")
-    parser.add_argument("--disable_rdns", "-n", action="store_true", help="disable kerberos reverse lookups")
+    parser.add_argument("--disable_rdns", action="store_true", help="disable kerberos reverse lookups")
     utility.add_args(parser)
     args = parser.parse_args()
     if not args.config:
@@ -237,13 +237,13 @@ def _parse_args(utility):
             if not password:
                 password = getpass()
             connectiontype = 'Keep-Alive'
-            rdns = False if args.disable_rdns else True
+            disable_rdns = True if args.disable_rdns else False
             args.conn_info = ConnectionInfo(
                 hostname, args.authentication,
                 args.username, password, scheme,
                 port, connectiontype, args.keytab,
                 args.dcip, ipaddress=args.ipaddress, service=args.service,
-                include_dir=args.includedir, rdns=rdns)
+                include_dir=args.includedir, disable_rdns=disable_rdns)
             try:
                 verify_conn_info(args.conn_info)
             except Exception as e:

--- a/txwinrm/krb5.py
+++ b/txwinrm/krb5.py
@@ -26,7 +26,7 @@ __all__ = [
 
 KRB5_CONF_TEMPLATE = (
     "# This file is managed by the txwinrm python module.\n"
-    "# NOTE: Any changes to the logging, libdefaults, domain_realm"
+    "# NOTE: Any changes to the logging, libdefaults, domain_realm\n"
     "# sections of this file will be overwritten.\n"
     "#\n"
     "\n"

--- a/txwinrm/krb5.py
+++ b/txwinrm/krb5.py
@@ -43,7 +43,7 @@ KRB5_CONF_TEMPLATE = (
     " ticket_lifetime = 24h\n"
     " renew_lifetime = 7d\n"
     " forwardable = true\n"
-    " rdns = {rdns}\n"
+    "{disable_rdns}"
     "\n"
     "[realms]\n"
     "{realms_text}"
@@ -99,8 +99,8 @@ class Config(object):
         """Initialize instance with data from KRB5_CONFIG."""
         self.path = self.get_path()
         self.includedirs = set()
+        self.disable_rdns = False
         self.realms, self.admin_servers = self.load()
-        self.rdns = True
 
         # For further usage by kerberos python module.
         os.environ['KRB5_CONFIG'] = self.path
@@ -133,7 +133,7 @@ class Config(object):
             self.save()
         defer.returnValue(None)
 
-    def add_kdc(self, realm, kdcs, rdns=True):
+    def add_kdc(self, realm, kdcs, disable_rdns=False):
         """Add realm and KDC to KRB5_CONFIG.
         Allow for comma separated string of kdcs with regex
         Use + or nothing to add, - to remove, * for admin_server
@@ -171,11 +171,11 @@ class Config(object):
         bad_kdcs = self.realms[realm].intersection(set(remove_kdcs))
         if (not new_kdcs and not bad_kdcs and
                 admin_server == self.admin_servers[realm] and
-                self.rdns == rdns):
+                self.disable_rdns == disable_rdns):
             # nothing to do
             return
 
-        self.rdns = rdns
+        self.disable_rdns = disable_rdns
         self.realms[realm] = self.realms[realm].union(new_kdcs) - bad_kdcs
         self.admin_servers[realm] = admin_server
         self.save()
@@ -244,9 +244,9 @@ class Config(object):
                         self.includedirs.add(match.group(1))
                 elif line.strip().startswith('rdns'):
                     try:
-                        self.rdns = True if line.split('=')[1].strip().lower() == 'true' else False
+                        self.disable_rdns = True if line.split('=')[1].strip() == 'false' else False
                     except Exception:
-                        self.rdns = True
+                        self.disable_rdns = False
                 elif in_realms_section:
                     line = line.strip()
                     if not line:
@@ -307,11 +307,11 @@ class Config(object):
                 INCLUDEDIR_TEMPLATE.format(
                     includedir=includedir))
 
-        rdns = 'true' if self.rdns else 'false'
+        disable_rdns = ' rdns = false\n' if self.disable_rdns else ''
         with open(self.path, 'w') as krb5_conf:
             krb5_conf.write(
                 KRB5_CONF_TEMPLATE.format(
-                    rdns=rdns,
+                    disable_rdns=disable_rdns,
                     includedir=''.join(includedir_list),
                     realms_text=''.join(realms_list),
                     domain_realm_text=''.join(domain_realm_list)))
@@ -352,7 +352,7 @@ class KinitProcessProtocol(ProcessProtocol):
 
 
 @defer.inlineCallbacks
-def kinit(username, password, kdc, includedir=None, rdns=True):
+def kinit(username, password, kdc, includedir=None, disable_rdns=False):
     """Perform kerberos initialization."""
     kinit = None
     for path in ('/usr/bin/kinit', '/usr/kerberos/bin/kinit'):
@@ -374,7 +374,7 @@ def kinit(username, password, kdc, includedir=None, rdns=True):
 
     if includedir:
         yield config.add_includedir(includedir)
-    config.add_kdc(realm, kdc, rdns)
+    config.add_kdc(realm, kdc, disable_rdns)
 
     ccname = config.get_ccname(username)
     dirname = os.path.dirname(ccname)
@@ -400,8 +400,8 @@ def ccname(username):
     return config.get_ccname(username)
 
 
-def add_trusted_realm(realm, kdc, rdns=True):
+def add_trusted_realm(realm, kdc, disable_rdns=False):
     """Add a trusted realm for cross realm authentication"""
     trusted_realm = realm.upper()
     global config
-    config.add_kdc(trusted_realm, kdc, rdns)
+    config.add_kdc(trusted_realm, kdc, disable_rdns)

--- a/txwinrm/util.py
+++ b/txwinrm/util.py
@@ -270,7 +270,7 @@ class AuthGSSClient(object):
                                            self._password,
                                            self._dcip,
                                            includedir=self._include_dir,
-                                           rdns=self._conn_info.rdns)
+                                           disable_rdns=self._conn_info.disable_rdns)
                 if kinit_result:
                     # this error is ok.  it just means more
                     # than one process is calling kinit
@@ -438,11 +438,11 @@ class ConnectionInfo(namedtuple(
         'code_page',
         'locale',
         'include_dir',
-        'rdns'])):
+        'disable_rdns'])):
     def __new__(cls, hostname, auth_type, username, password, scheme, port,
                 connectiontype, keytab, dcip, timeout=60, trusted_realm='',
                 trusted_kdc='', ipaddress='', service='', envelope_size=512000,
-                code_page=65001, locale='en-US', include_dir=None, rdns=True):
+                code_page=65001, locale='en-US', include_dir=None, disable_rdns=False):
         if not ipaddress:
             ipaddress = hostname
         if not service:
@@ -454,7 +454,7 @@ class ConnectionInfo(namedtuple(
                                                   trusted_realm, trusted_kdc,
                                                   ipaddress, service,
                                                   envelope_size, code_page, locale,
-                                                  include_dir, rdns)
+                                                  include_dir, disable_rdns)
 
 
 def verify_include_dir(conn_info):


### PR DESCRIPTION
Default is true, so no need to set it if not disabling rdns.
User could have optional config file which disables it, so do not
add conflicts.