### PR TITLE
	Test if current shell id is active for LongRunningCommand

### DIFF
--- a/txwinrm/request/enum_shells.xml
+++ b/txwinrm/request/enum_shells.xml
@@ -1,0 +1,18 @@
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:wsman="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"> 
+  <s:Header> 
+    <wsa:To>http://SORINOTEST05:5985/wsman</wsa:To> 
+    <wsman:ResourceURI s:mustUnderstand="true"> http://schemas.microsoft.com/wbem/wsman/1/windows/shell </wsman:ResourceURI> 
+    <wsa:ReplyTo> 
+      <wsa:Address s:mustUnderstand="true"> http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous </wsa:Address> 
+    </wsa:ReplyTo> 
+    <wsa:Action s:mustUnderstand="true"> http://schemas.xmlsoap.org/ws/2004/09/enumeration/Enumerate </wsa:Action> 
+    <wsman:MaxEnvelopeSize s:mustUnderstand="true">153600</wsman:MaxEnvelopeSize> 
+    <wsa:MessageID>uuid:08E59736-6A1B-4560-8442-64E4D7A26EB5</wsa:MessageID> 
+    <wsman:Locale xml:lang="en-US" s:mustUnderstand="false" /> 
+    <wsman:OperationTimeout>PT60.000S</wsman:OperationTimeout> 
+  </s:Header> 
+  <s:Body> 
+    <wsen:Enumerate> </wsen:Enumerate> 
+  </s:Body> 
+</s:Envelope>
+

--- a/txwinrm/request/pull_shells.xml
+++ b/txwinrm/request/pull_shells.xml
@@ -1,0 +1,34 @@
+<s:Envelope
+   xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+   xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+   xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+   xmlns:wsman="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">
+   <s:Header>
+     <wsa:To>http://SORINOTEST05:80/wsman</wsa:To>
+     <wsman:ResourceURI s:mustUnderstand="true">
+       http://schemas.microsoft.com/wbem/wsman/1/windows/shell
+     </wsman:ResourceURI>
+     <wsa:ReplyTo>
+       <wsa:Address s:mustUnderstand="true">
+         http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous
+       </wsa:Address>
+     </wsa:ReplyTo>
+     <wsa:Action s:mustUnderstand="true">
+       http://schemas.xmlsoap.org/ws/2004/09/enumeration/Pull
+     </wsa:Action>
+     <wsman:MaxEnvelopeSize s:mustUnderstand="true">153600</wsman:MaxEnvelopeSize>
+     <wsa:MessageID>
+       uuid:BE9EDB22-23A3-489A-B025-ED7F3461E4AB</wsa:MessageID>
+     <wsman:Locale xml:lang="en-US" s:mustUnderstand="false" />
+     <wsman:OperationTimeout>PT60.000S</wsman:OperationTimeout>
+   </s:Header>
+   <s:Body>
+     <wsen:Pull>
+       <wsen:EnumerationContext
+         xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration">
+         uuid:{uuid}
+         </wsen:EnumerationContext>
+       <wsen:MaxElements>5</wsen:MaxElements>
+     </wsen:Pull>
+   </s:Body>
+ </s:Envelope>

--- a/txwinrm/shell.py
+++ b/txwinrm/shell.py
@@ -214,6 +214,24 @@ def create_single_shot_command(conn_info):
     return SingleShotCommand(sender)
 
 
+def _find_enum_context(elem):
+    e_context = None
+    xpath = './/{{{}}}EnumerationContext'.format(c.XML_NS_ENUMERATION)
+    ctxt_elem = elem.find(xpath)
+    if ctxt_elem is not None:
+        e_context = ctxt_elem.text.split(':')[1]
+    return e_context
+
+
+def _find_shell_ids(elem):
+    ids = []
+    xpath = './/{{{}}}ShellId'.format(c.XML_NS_MSRSP)
+    shells = elem.findall(xpath)
+    for shell in shells:
+        ids.append(shell.text)
+    return ids
+
+
 class LongRunningCommand(object):
 
     def __init__(self, sender):
@@ -223,9 +241,25 @@ class LongRunningCommand(object):
         self._exit_code = None
 
     @defer.inlineCallbacks
+    def is_shell_active(self, shell_id):
+        if shell_id is None:
+            defer.returnValue(False)
+        elem = yield self._sender.send_request('enum_shells')
+        enum_context = _find_enum_context(elem)
+        if enum_context is None:
+            defer.returnValue(False)
+        elem = yield self._sender.send_request('pull_shells', uuid=enum_context)
+        shell_ids = _find_shell_ids(elem)
+        if shell_id in shell_ids:
+            defer.returnValue(True)
+        else:
+            defer.returnValue(False)
+
+    @defer.inlineCallbacks
     def start(self, command_line, ps_script=None):
-        log.debug("LongRunningCommand run_command: {0}".format(command_line))
-        if self._shell_id is None:
+        log.debug("LongRunningCommand run_command: {0}".format(command_line + ps_script))
+        active_shell = yield self.is_shell_active(self._shell_id)
+        if active_shell is False:
             elem = yield self._sender.send_request('create')
             self._shell_id = _find_shell_id(elem)
         if ps_script is not None:
@@ -234,7 +268,7 @@ class LongRunningCommand(object):
             command_line_elem = _build_command_line_elem(command_line)
         log.debug('LongRunningCommand run_command: sending command request '
                   '(shell_id={0}, command_line_elem={1})'.format(
-                    self._shell_id, command_line_elem))
+                      self._shell_id, command_line_elem))
         try:
             command_elem = yield self._sender.send_request(
                 'command', shell_id=self._shell_id,

--- a/txwinrm/shell.py
+++ b/txwinrm/shell.py
@@ -258,7 +258,11 @@ class LongRunningCommand(object):
     @defer.inlineCallbacks
     def start(self, command_line, ps_script=None):
         log.debug("LongRunningCommand run_command: {0}".format(command_line + ps_script))
-        active_shell = yield self.is_shell_active(self._shell_id)
+        try:
+            active_shell = yield self.is_shell_active(self._shell_id)
+        except TimeoutError:
+            yield self.delete_and_close()
+            raise
         if active_shell is False:
             elem = yield self._sender.send_request('create')
             self._shell_id = _find_shell_id(elem)

--- a/txwinrm/util.py
+++ b/txwinrm/util.py
@@ -40,7 +40,7 @@ _NANOSECONDS_PATTERN = re.compile(r'\.(\d{6})(\d{3})')
 _REQUEST_TEMPLATE_NAMES = (
     'enumerate', 'pull',
     'create', 'command', 'send', 'receive', 'signal', 'delete',
-    'subscribe', 'event_pull', 'unsubscribe')
+    'subscribe', 'event_pull', 'unsubscribe', 'enum_shells', 'pull_shells')
 _REQUEST_TEMPLATE_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), 'request')
 _REQUEST_TEMPLATES = {}


### PR DESCRIPTION
Fixes ZPS-1770

If server reboots or shell is deleted, we'll need to create a new one