### PR TITLE
Fix 'kerberos' referenced before assignment

### DIFF
--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -66,7 +66,7 @@ from .enumerate import (
     _MAX_REQUESTS_PER_ENUMERATION
 )
 from .SessionManager import SESSION_MANAGER, Session
-from .twisted_utils import add_timeout
+from .twisted_utils import with_timeout
 kerberos = None
 LOG = logging.getLogger('winrm')
 
@@ -103,9 +103,11 @@ class WinRMSession(Session):
     def semrun(self, fn, *args, **kwargs):
         """Run fn(*args, **kwargs) under a DeferredSemaphore with a timeout."""
         return self.sem.run(
-            add_timeout,
-            fn(*args, **kwargs),
-            self._conn_info.timeout)
+            with_timeout,
+            fn=fn,
+            args=args,
+            kwargs=kwargs,
+            seconds=self._conn_info.timeout)
 
     def is_kerberos(self):
         return self._conn_info.auth_type == 'kerberos'

--- a/txwinrm/twisted_utils.py
+++ b/txwinrm/twisted_utils.py
@@ -11,6 +11,14 @@ from twisted.internet import defer, error, reactor
 from twisted.python import failure
 
 
+def with_timeout(fn, args=None, kwargs=None, seconds=None, exception_class=error.TimeoutError):
+    """Execute asynchronous function fn(*args, **kwargs) with a timeout."""
+    return add_timeout(
+        deferred=fn(*args, **kwargs),
+        seconds=seconds,
+        exception_class=exception_class)
+
+
 def add_timeout(deferred, seconds, exception_class=error.TimeoutError):
     """Return new Deferred that will errback exception_class after seconds."""
     deferred_with_timeout = defer.Deferred()


### PR DESCRIPTION
DeferredSemaphore.run(fn, *args, **kwargs) has the method signature it
does because it defers the creation of the fn(*args, **kwargs) deferred
until the semaphore can be acquired. My change to wrap a timeout around
all functions run under the semaphore in e5ca422 broke this by causing
fn(*args, **kwargs) to be executed before the semaphore could be
acquired.

This change restores the execution of fn(*args, **kwargs) to after the
semaphore is acquired, and thus fixes the resulting 'kerberos'
referenced before assignment problems it caused in the Windows ZenPack.

Refs ZPS-1795.