### PR TITLE
Fix memory leaks

### DIFF
--- a/txwinrm/util.py
+++ b/txwinrm/util.py
@@ -686,6 +686,7 @@ class RequestSender(object):
                 response.code, message))
         defer.returnValue(response)
 
+    @defer.inlineCallbacks
     def close_connections(self):
         # close connections
         # return a Deferred()


### PR DESCRIPTION
Fixes ZPS-1584

SessionManager was holding onto references to WinRMSessions. HTTPConnectionPools
were not being deleted either.  These changes seem to have curbed memory growth.