### PR TITLE
we should not delete pool.  allow twisted to take care of it

### DIFF
--- a/txwinrm/shell.py
+++ b/txwinrm/shell.py
@@ -334,6 +334,10 @@ class LongRunningCommand(object):
         except TimeoutError:
             # close_connections done in receive() for TimeoutError
             raise
+        except RequestError:
+            yield self.delete_and_close()
+            self._shell_id = None
+            defer.returnValue(CommandResponse([], [], 0))
         try:
             yield self._sender.send_request(
                 'signal',
@@ -343,6 +347,7 @@ class LongRunningCommand(object):
         except RequestError:
             pass
         yield self.delete_and_close()
+        self._shell_id = None
         defer.returnValue(CommandResponse(stdout, stderr, self._exit_code))
 
 

--- a/txwinrm/util.py
+++ b/txwinrm/util.py
@@ -625,7 +625,6 @@ class RequestSender(object):
         @defer.inlineCallbacks
         def reset_agent_resend(sender, request, body_producer):
             yield self.close_connections()
-            sender.agent = _get_agent()
             if sender.gssclient is not None:
                 # do some cleanup first.  memory leaks were occurring
                 sender.gssclient.cleanup()
@@ -695,9 +694,7 @@ class RequestSender(object):
             self.agent.closeCachedConnections()
         elif self.agent:
             # twisted 12 returns a Deferred from the pool
-            # we need to also dereference the pool so it can go away
             yield self.agent._pool.closeCachedConnections()
-            self.agent._pool = None
         # no agent
         defer.returnValue(None)
 


### PR DESCRIPTION
keep sessions and agents around.  we'll only have to reallocate them later.  doesn't add any new burdens to zenpython

Fixes ZPS-1851, ZPS-1584
