### PR TITLE
No need to reset agent in WinrmSession.

### DIFF
--- a/txwinrm/SessionManager.py
+++ b/txwinrm/SessionManager.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2016-2017, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -26,6 +26,8 @@ of transactions/requests being made through a single Session
 import copy
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.protocol import Factory
+Factory.noisy = False
 
 
 class Session(object):

--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2013, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2016-2017, all rights reserved.
 #
 # This content is made available according to terms specified in the LICENSE
 # file at the top-level directory of this package.
@@ -173,7 +173,6 @@ class WinRMSession(Session):
             # only retry if using kerberos
             self._token = None
             yield self.close_cached_connections()
-            self._agent = _get_agent()
             self._login_d = None
             if self._gssclient is not None:
                 self._gssclient.cleanup()


### PR DESCRIPTION
keep agent.  just close cached connections and reconnect.  related
to previous fix in 1.2.24 which introduced keeping agents around.

Also, set twisted Factory.noisy to False just in case there are
twisted logs holding onto factory references, which causes memory leaks.