### PR TITLE
Add resolution to error message for concurrent operations

### DIFF
--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -213,6 +213,8 @@ class WinRMSession(Session):
                 reader = _ErrorReader()
             response.deliverBody(reader)
             message = yield reader.d
+            if 'maximum number of concurrent operations for this user has been exceeded' in message:
+                message += '  To fix this, increase the MaxConcurrentOperationsPerUser WinRM Configuration option and restart the winrm service.'
             raise RequestError("HTTP status: {}. {}".format(
                 response.code, message))
         returnValue(response)

--- a/txwinrm/shell.py
+++ b/txwinrm/shell.py
@@ -285,7 +285,6 @@ class LongRunningCommand(object):
     @defer.inlineCallbacks
     def start(self, command_line, ps_script=None):
         log.debug("LongRunningCommand run_command: {0}".format(command_line + ps_script))
-        yield self.get_active_shell()
         try:
             active_shell = yield self.get_active_shell()
         except TimeoutError:

--- a/txwinrm/util.py
+++ b/txwinrm/util.py
@@ -681,6 +681,8 @@ class RequestSender(object):
                 reader = _ErrorReader()
             response.deliverBody(reader)
             message = yield reader.d
+            if 'maximum number of concurrent operations for this user has been exceeded' in message:
+                message += '  To fix this, increase the MaxConcurrentOperationsPerUser WinRM Configuration option and restart the winrm service.'
             raise RequestError("HTTP status: {0}. {1}".format(
                 response.code, message))
         defer.returnValue(response)


### PR DESCRIPTION
When the concurrent operations has been exceeded for winrm, we start
to see these errors.  This message will let users know how to fix it.
Increase the winrm config option and restart the winrm service or at
least restart the service.

also, removed extra call to get_active_shell() in long running command.

https://windowsserver.uservoice.com/forums/301869-powershell/suggestions/15669870-winrm-concurrent-operations-increase-to-eventual