### PR TITLE
don't use klist to determine bad includedir

### DIFF
--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -214,7 +214,8 @@ class WinRMSession(Session):
             response.deliverBody(reader)
             message = yield reader.d
             if 'maximum number of concurrent operations for this user has been exceeded' in message:
-                message += '  To fix this, increase the MaxConcurrentOperationsPerUser WinRM Configuration option and restart the winrm service.'
+                message += '  To fix this, increase the MaxConcurrentOperationsPerUser WinRM'\
+                           ' Configuration option to 4294967295 and restart the winrm service.'
             raise RequestError("HTTP status: {}. {}".format(
                 response.code, message))
         returnValue(response)

--- a/txwinrm/util.py
+++ b/txwinrm/util.py
@@ -682,7 +682,8 @@ class RequestSender(object):
             response.deliverBody(reader)
             message = yield reader.d
             if 'maximum number of concurrent operations for this user has been exceeded' in message:
-                message += '  To fix this, increase the MaxConcurrentOperationsPerUser WinRM Configuration option and restart the winrm service.'
+                message += '  To fix this, increase the MaxConcurrentOperationsPerUser WinRM'\
+                           ' Configuration option to 4294967295 and restart the winrm service.'
             raise RequestError("HTTP status: {0}. {1}".format(
                 response.code, message))
         defer.returnValue(response)


### PR DESCRIPTION
Fixes ZPS-2072

When yielding to the klist process in add_includedir, we could have
lost control of writing the krb5.conf file.  now we will just write
it out, then check for an error from kinit.  if there is one then
remove the includedir and try again