### PR TITLE
Keep number of open shells as low as possible

### DIFF
--- a/txwinrm/SessionManager.py
+++ b/txwinrm/SessionManager.py
@@ -144,6 +144,21 @@ class SessionManager(object):
         # Used to keep track of sessions.
         self._sessions = {}
 
+        # Used to keep track of shells
+        # each host will keep a single shell
+        self._shells = {}
+
+    def get_shell(self, host):
+        return self._shells.get(host, None)
+
+    def add_shell(self, host, shell):
+        self._shells[host] = shell
+
+    def remove_shell(self, host):
+        shell = self.get_shell(host)
+        if shell:
+            self._shells.pop(host)
+
     def get_connection(self, key):
         """Return the session for a given key."""
         if key is None:
@@ -216,6 +231,7 @@ class SessionManager(object):
     @inlineCallbacks
     def deferred_logout(self, key):
         session = self.get_connection(key)
+        self.remove_shell(key[0])
         yield session._deferred_logout()
         returnValue(None)
 

--- a/txwinrm/SessionManager.py
+++ b/txwinrm/SessionManager.py
@@ -142,10 +142,13 @@ class SessionManager(object):
 
     def __init__(self):
         # Used to keep track of sessions.
+        # a session entry uses a key that is a tuple
+        # of (ipaddress, some_other_content)
         self._sessions = {}
 
         # Used to keep track of shells
         # each host will keep a single shell
+        # store shells by ipaddress
         self._shells = {}
 
     def get_shell(self, host):
@@ -230,8 +233,11 @@ class SessionManager(object):
 
     @inlineCallbacks
     def deferred_logout(self, key):
+        # first, get the session from the key
         session = self.get_connection(key)
+        # remove shell based on ipaddress from key
         self.remove_shell(key[0])
+        # close current connection and do cleanup for session
         yield session._deferred_logout()
         returnValue(None)
 

--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -335,6 +335,7 @@ class WinRMClient(object):
     @inlineCallbacks
     def _create_shell(self):
         # first, check to see if we have an existing shell
+        # any errors will be raised from send_request call(s)
         shell = SESSION_MANAGER.get_shell(self._conn_info.ipaddress)
         if shell is None:
             # check for oldest active shell next
@@ -345,11 +346,10 @@ class WinRMClient(object):
             shell = create_shell_from_elem(elem)
             self._shell_id = shell.ShellId
             # save shell to Session Manager
-            SESSION_MANAGER.add_shell(self._conn_info.ipaddress, shell)
         else:
             self._shell_id = shell.ShellId
             # update current shell if needed
-            SESSION_MANAGER.add_shell(self._conn_info.ipaddress, shell)
+        SESSION_MANAGER.add_shell(self._conn_info.ipaddress, shell)
         returnValue(self._shell_id)
 
     @inlineCallbacks

--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -46,7 +46,6 @@ from .util import (
     ET,
 )
 from .shell import (
-    _find_shell_id,
     _build_command_line_elem,
     _build_ps_command_line_elem,
     _find_command_id,
@@ -55,18 +54,34 @@ from .shell import (
     _find_exit_code,
     CommandResponse,
     _stripped_lines,
-    _find_enum_context
+    _get_active_shell,
+    _get_active_shells
 )
 from .enumerate import (
     DEFAULT_RESOURCE_URI,
     SaxResponseHandler,
-    create_parser_and_factory,
-    _MAX_REQUESTS_PER_ENUMERATION
+    _MAX_REQUESTS_PER_ENUMERATION,
+    ItemsAccumulator
 )
 from .SessionManager import SESSION_MANAGER, Session
 from .twisted_utils import with_timeout
 kerberos = None
 LOG = logging.getLogger('winrm')
+
+
+def create_shell_from_elem(elem):
+    accumulator = ItemsAccumulator()
+    accumulator.new_item()
+    for item in ['ShellId', 'Owner', 'ClientIP', 'ShellRunTime', 'ShellInactivity', 'IdleTimeOut']:
+        xpath = './/{{{}}}{}'.format(c.XML_NS_MSRSP, item)
+        try:
+            accumulator.add_property(item, elem.findtext(xpath).strip())
+        except AttributeError as e:
+            if item == 'ShellId':
+                raise Exception('Invalid response from create shell request: {}'.format(e))
+            # as long as we have a valid ShellId we should be fine
+            accumulator.add_property(item, '')
+    return accumulator.items[0]
 
 
 class WinRMSession(Session):
@@ -283,12 +298,14 @@ class WinRMClient(object):
 
     Contains core functionality for various types of winrm based clients
     """
-    def __init__(self, conn_info):
+    def __init__(self, conn_info, min_runtime=600, delete_shell=False):
         verify_conn_info(conn_info)
         self.key = None
         self._conn_info = conn_info
         self.ps_script = None
         self._shell_id = None
+        self._min_runtime = min_runtime
+        self._del_shell = delete_shell
 
     def _session(self):
         return SESSION_MANAGER.get_connection(self.key)
@@ -316,41 +333,28 @@ class WinRMClient(object):
         returnValue(response)
 
     @inlineCallbacks
-    def get_active_shell(self):
-        elem = yield self.send_request('enum_shells')
-        enum_context = _find_enum_context(elem)
-        if enum_context is None:
-            returnValue(False)
-        response = yield self.send_request('pull_shells', uuid=enum_context)
-        body = ET.tostring(response)
-        parser, factory = create_parser_and_factory()
-        parser.feed(body)
-        # shell owner is in netbios format DOMAIN\user or just local user
-        user_domain = self._conn_info.username.split('@')
-        try:
-            # get domain user as netbios
-            user = (user_domain[1].split('.')[0] + '\\' + user_domain[0]).lower()
-        except IndexError:
-            # local user, no netbios
-            user = user_domain[0].lower()
-        found_shell = False
-        for shell in factory.items:
-            if user == shell.Owner.lower():
-                self._shell_id = shell.ShellId
-                found_shell = True
-        returnValue(found_shell)
-
-    @inlineCallbacks
     def _create_shell(self):
-        # check for active shell first
-        active_shell = yield self.get_active_shell()
-        if active_shell is False:
+        # first, check to see if we have an existing shell
+        shell = SESSION_MANAGER.get_shell(self._conn_info.ipaddress)
+        if shell is None:
+            # check for oldest active shell next
+            shell = yield _get_active_shell(self, self._conn_info, min_runtime=self._min_runtime)
+        if shell is None:
+            # create new shell
             elem = yield self.send_request('create')
-            self._shell_id = _find_shell_id(elem)
+            shell = create_shell_from_elem(elem)
+            self._shell_id = shell.ShellId
+            # save shell to Session Manager
+            SESSION_MANAGER.add_shell(self._conn_info.ipaddress, shell)
+        else:
+            self._shell_id = shell.ShellId
+            # update current shell if needed
+            SESSION_MANAGER.add_shell(self._conn_info.ipaddress, shell)
         returnValue(self._shell_id)
 
     @inlineCallbacks
     def _delete_shell(self, shell_id):
+        SESSION_MANAGER.remove_shell(self._conn_info.ipaddress)
         yield self.send_request('delete', shell_id=shell_id)
         returnValue(None)
 
@@ -397,8 +401,8 @@ class WinRMClient(object):
 
 class SingleCommandClient(WinRMClient):
     """Client to send a single command to a winrm device"""
-    def __init__(self, conn_info):
-        super(SingleCommandClient, self).__init__(conn_info)
+    def __init__(self, conn_info, min_runtime=600, delete_shell=False):
+        super(SingleCommandClient, self).__init__(conn_info, min_runtime=min_runtime, delete_shell=delete_shell)
         self.key = (self._conn_info.ipaddress, 'short')
 
     @inlineCallbacks
@@ -440,6 +444,8 @@ class SingleCommandClient(WinRMClient):
             cmd_response = yield self._run_command(self._shell_id, command_line)
         except TimeoutError:
             self.close_connection()
+        if self._del_shell:
+            self._delete_shell(self._shell_id)
         self.close_connection()
         returnValue(cmd_response)
 

--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -344,11 +344,8 @@ class WinRMClient(object):
             # create new shell
             elem = yield self.send_request('create')
             shell = create_shell_from_elem(elem)
-            self._shell_id = shell.ShellId
-            # save shell to Session Manager
-        else:
-            self._shell_id = shell.ShellId
-            # update current shell if needed
+        self._shell_id = shell.ShellId
+        # save shell
         SESSION_MANAGER.add_shell(self._conn_info.ipaddress, shell)
         returnValue(self._shell_id)
 

--- a/txwinrm/request/pull_shells.xml
+++ b/txwinrm/request/pull_shells.xml
@@ -28,7 +28,7 @@
          xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration">
          uuid:{uuid}
          </wsen:EnumerationContext>
-       <wsen:MaxElements>5</wsen:MaxElements>
+       <wsen:MaxElements>100</wsen:MaxElements>
      </wsen:Pull>
    </s:Body>
  </s:Envelope>

--- a/txwinrm/shell.py
+++ b/txwinrm/shell.py
@@ -123,11 +123,6 @@ def _find_shell_id(elem):
     return elem.findtext(xpath).strip()
 
 
-def _find_shell_client_ip(elem):
-    xpath = './/{%s}Selector[@Name="ClientIP"]' % c.XML_NS_WS_MAN
-    return elem.findtext(xpath).strip()
-
-
 def _find_command_id(elem):
     xpath = './/{%s}CommandId' % c.XML_NS_MSRSP
     return elem.findtext(xpath).strip()
@@ -275,6 +270,9 @@ def _get_active_shell(request_sender, conn_info, min_runtime=600):
     def get_runtime(runtime):
         # return total runtime in seconds
         # ShellRunTime is specified as P<days>DT<hours>H<minutes>M<seconds>S
+        # e.g. P1DT1H1M1S is a runtime of of 1 day, 1 hour, 1 minute, and 1 second
+        # we'll calculate the total number of seconds a shell has been running using
+        # these numbers
         try:
             rt_match = re.match('P(?P<d>\d+)DT(?P<h>\d+)H(?P<m>\d+)M(?P<s>\d+)S', runtime)
             return int(rt_match.group('s')) + (int(rt_match.group('m')) * 60) + (int(rt_match.group('h')) * 3600) + (int(rt_match.group('d')) * 86400)

--- a/txwinrm/shell.py
+++ b/txwinrm/shell.py
@@ -123,6 +123,11 @@ def _find_shell_id(elem):
     return elem.findtext(xpath).strip()
 
 
+def _find_shell_client_ip(elem):
+    xpath = './/{%s}Selector[@Name="ClientIP"]' % c.XML_NS_WS_MAN
+    return elem.findtext(xpath).strip()
+
+
 def _find_command_id(elem):
     xpath = './/{%s}CommandId' % c.XML_NS_MSRSP
     return elem.findtext(xpath).strip()
@@ -234,38 +239,73 @@ def _find_shell_ids(elem):
     return ids
 
 
+@defer.inlineCallbacks
+def _get_active_shells(request_sender):
+    elem = yield request_sender.send_request('enum_shells')
+    enum_context = _find_enum_context(elem)
+    if enum_context is None:
+        defer.returnValue(None)
+    response = yield request_sender.send_request('pull_shells', uuid=enum_context)
+    body = ElementTree.tostring(response)
+    parser, factory = create_parser_and_factory()
+    parser.feed(body)
+    defer.returnValue(factory.items)
+
+
+@defer.inlineCallbacks
+def _get_active_shell(request_sender, conn_info, min_runtime=600):
+    """Sift through existing shells to find what should be the last active shell
+    created by our user.  Compare against minimum runtime so we grab the oldest
+    shell.  something less than min_runtime could have been created by a different
+    client.  sender can be RequestSender or WinRMClient.  conn_info is a
+    txwinrm.util.ConnectionInfo instance
+    """
+    shells = yield _get_active_shells(request_sender)
+    active_shell = None
+
+    user_domain = conn_info.username.split('@')
+    try:
+        # get domain user as netbios
+        user = (user_domain[1].split('.')[0] + '\\' + user_domain[0]).lower()
+    except IndexError:
+        # local user, no netbios
+        # user_domain[0] will always exist
+        user = user_domain[0].lower()
+
+    def get_runtime(runtime):
+        # return total runtime in seconds
+        # ShellRunTime is specified as P<days>DT<hours>H<minutes>M<seconds>S
+        try:
+            rt_match = re.match('P(?P<d>\d+)DT(?P<h>\d+)H(?P<m>\d+)M(?P<s>\d+)S', runtime)
+            return int(rt_match.group('s')) + (int(rt_match.group('m')) * 60) + (int(rt_match.group('h')) * 3600) + (int(rt_match.group('d')) * 86400)
+        except Exception:
+            return 0
+
+    for shell in shells:
+        if user == shell.Owner.lower():
+            runtime = get_runtime(shell.ShellRunTime)
+            if runtime > min_runtime:
+                # found possible candidate, test against previous
+                if active_shell is not None:
+                    prev_runtime = get_runtime(active_shell.ShellRunTime)
+                    if runtime > prev_runtime:
+                        active_shell = shell
+                else:
+                    active_shell = shell
+    defer.returnValue(active_shell)
+
+
 class LongRunningCommand(object):
 
-    def __init__(self, sender):
+    def __init__(self, sender, min_runtime=600):
         self._sender = sender
         self._shell_id = None
         self._command_id = None
         self._exit_code = None
 
-    @defer.inlineCallbacks
-    def get_active_shell(self):
-        elem = yield self._sender.send_request('enum_shells')
-        enum_context = _find_enum_context(elem)
-        if enum_context is None:
-            defer.returnValue(False)
-        response = yield self._sender.send_request('pull_shells', uuid=enum_context)
-        body = ElementTree.tostring(response)
-        parser, factory = create_parser_and_factory()
-        parser.feed(body)
-        user_domain = self._sender._sender._conn_info.username.split('@')
-        try:
-            # get domain user as netbios
-            user = (user_domain[1].split('.')[0] + '\\' + user_domain[0]).lower()
-        except IndexError:
-            # local user, no netbios
-            # user_domain[0] will always exist
-            user = user_domain[0].lower()
-        found_shell = False
-        for shell in factory.items:
-            if user == shell.Owner.lower():
-                self._shell_id = shell.ShellId
-                found_shell = True
-        defer.returnValue(found_shell)
+        # attach to shell with a minimum runtime of x seconds to know
+        # that our user created the shell
+        self._min_runtime = min_runtime
 
     @defer.inlineCallbacks
     def is_shell_active(self, shell_id):
@@ -285,14 +325,19 @@ class LongRunningCommand(object):
     @defer.inlineCallbacks
     def start(self, command_line, ps_script=None):
         log.debug("LongRunningCommand run_command: {0}".format(command_line + ps_script))
-        try:
-            active_shell = yield self.get_active_shell()
-        except TimeoutError:
-            yield self._sender.close_connections()
-            raise
-        if active_shell is False:
-            elem = yield self._sender.send_request('create')
-            self._shell_id = _find_shell_id(elem)
+        if self._shell_id is None:
+            try:
+                shell = yield _get_active_shell(self._sender,
+                                                self._sender._sender._conn_info,
+                                                min_runtime=self._min_runtime)
+            except TimeoutError:
+                yield self._sender.close_connections()
+                raise
+            if shell is None:
+                elem = yield self._sender.send_request('create')
+                self._shell_id = _find_shell_id(elem)
+            else:
+                self._shell_id = shell.ShellId
         if ps_script is not None:
             command_line_elem = _build_ps_command_line_elem(command_line, ps_script)
         else:
@@ -309,6 +354,7 @@ class LongRunningCommand(object):
             yield self._sender.close_connections()
             raise
         self._command_id = _find_command_id(command_elem)
+        defer.returnValue(self._command_id)
 
     @defer.inlineCallbacks
     def receive(self):


### PR DESCRIPTION
This update will allow us to use a single shell per device.  On a service
startup, like zenpython, we'll probably end up with a few shells.  After
running for a while, all clients will start to use the longest running
shell owned by a specific user.  After a daemon restart, if the shell has
not timed out, we can reconnect to it and continue as if nothing happened.
On Session logout, remove the shell for the device ip.  On the next query,
retrieve the oldest running session.  This will be good for services like
zenmodeler that do not run very often.

This also takes into account older versions of windows zp or other zenpacks
that are not using this version of txwinrm.