### PR TITLE
Fix so that we will use a single shell for short commands

### DIFF
--- a/txwinrm/util.py
+++ b/txwinrm/util.py
@@ -625,10 +625,7 @@ class RequestSender(object):
         @defer.inlineCallbacks
         def reset_agent_resend(sender, request, body_producer):
             yield self.close_connections()
-            if sender.gssclient is not None:
-                # do some cleanup first.  memory leaks were occurring
-                sender.gssclient.cleanup()
-                sender.gssclient = None
+            if sender.is_kerberos():
                 try:
                     yield sender._set_url_and_headers()
                     encrypted_request = sender.gssclient.encrypt_body(request)
@@ -698,7 +695,9 @@ class RequestSender(object):
         elif self.agent:
             # twisted 12 returns a Deferred from the pool
             yield self.agent._pool.closeCachedConnections()
-        # no agent
+        if self.gssclient is not None:
+            self.gssclient.cleanup()
+            self.gssclient = None
         defer.returnValue(None)
 
 

--- a/txwinrm/winrs.py
+++ b/txwinrm/winrs.py
@@ -12,8 +12,8 @@ import cmd
 from pprint import pprint
 from twisted.internet import reactor, defer, task, threads
 from . import app
-from .shell import create_remote_shell
-from .WinRMClient import SingleCommandClient, LongCommandClient
+from .shell import create_remote_shell, create_long_running_command
+from .WinRMClient import SingleCommandClient
 
 
 def print_output(stdout, stderr):
@@ -57,7 +57,7 @@ class WinrsCmd(cmd.Cmd):
 @defer.inlineCallbacks
 def long_running_main(args):
     try:
-        client = LongCommandClient(args.conn_info)
+        client = create_long_running_command(args.conn_info)
         yield client.start(args.command)
         for i in xrange(5):
             stdout, stderr = yield task.deferLater(


### PR DESCRIPTION
Revert reusing a single shell for lifetime of collection

Fixes ZPS-2132

Long commands will create a shell, then delete it when done.

Revert single shell usage for single/long commands.  will revisit this at a later date.
