### PR TITLE
make kerberos global

### DIFF
--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -205,8 +205,9 @@ class WinRMSession(Session):
                     raise e
             if response.code == UNAUTHORIZED:
                 if self.is_kerberos():
-                    if not kerberos:
-                        from .util import kerberos
+                    global kerberos
+                    if kerberos is None:
+                        import kerberos
                     auth_header = response.headers.getRawHeaders('WWW-Authenticate')[0]
                     auth_details = get_auth_details(auth_header)
                     try:


### PR DESCRIPTION
Fixes ZPS-2738

kerberos is a global variable, not local.  also, import it directly
as it may not have been imported in util yet.