### PR TITLE
Add connection timeout option, possible memory leak fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,13 +86,6 @@ Current Feature Support
 -  WMI Associators queries
 
 
-Future Feature Support
-----------------------
-
--  NTLM authentication (local accounts)
--  Kerberos keytab support
-
-
 Configuring the Target Windows Machines
 ---------------------------------------
 

--- a/txwinrm/app.py
+++ b/txwinrm/app.py
@@ -222,6 +222,7 @@ def _parse_args(utility):
     parser.add_argument("--service", "-e", help='http/https/wsman', default='http')
     parser.add_argument("--includedir", help="valid includedir")
     parser.add_argument("--disable_rdns", action="store_true", help="disable kerberos reverse lookups")
+    parser.add_argument("--connect_timeout", help='timeout connecting after x seconds', default=60)
     utility.add_args(parser)
     args = parser.parse_args()
     if not args.config:
@@ -238,12 +239,13 @@ def _parse_args(utility):
                 password = getpass()
             connectiontype = 'Keep-Alive'
             disable_rdns = True if args.disable_rdns else False
+            connect_timeout = getattr(args, 'connect_timeout', 60)
             args.conn_info = ConnectionInfo(
                 hostname, args.authentication,
                 args.username, password, scheme,
                 port, connectiontype, args.keytab,
                 args.dcip, ipaddress=args.ipaddress, service=args.service,
-                include_dir=args.includedir, disable_rdns=disable_rdns)
+                include_dir=args.includedir, disable_rdns=disable_rdns, connect_timeout=connect_timeout)
             try:
                 verify_conn_info(args.conn_info)
             except Exception as e:

--- a/txwinrm/twisted_utils.py
+++ b/txwinrm/twisted_utils.py
@@ -27,6 +27,7 @@ def add_timeout(deferred, seconds, exception_class=error.TimeoutError):
         deferred.cancel()
 
         if not deferred_with_timeout.called:
+            print 'deferred_with_timeout.called'
             deferred_with_timeout.errback(exception_class())
 
     delayed_timeout = reactor.callLater(seconds, fire_timeout)


### PR DESCRIPTION
Fixes ZPS-2829

Added a connection timeout so that we can return quicker from a failed connection
This will allow for fewer tasks to be in a running state.  connections should only take a few seconds at most
Pool connections seem to keep growing in memory.  Destroy agent and connection pool when closing a connection
Also allow for starting an immediate close connection