### PR TITLE
do not close active connections

### DIFF
--- a/txwinrm/SessionManager.py
+++ b/txwinrm/SessionManager.py
@@ -225,14 +225,16 @@ class SessionManager(object):
         timeout = DEFAULT_TIMEOUT + 5
         if immediately:
             timeout = 0
-        session._logout_dc = reactor.callLater(timeout, self.deferred_logout, key)
+        if not session._clients:
+            session._logout_dc = reactor.callLater(timeout, self.deferred_logout, key)
 
     @inlineCallbacks
     def deferred_logout(self, key):
         # first, get the session from the key
         session = self.get_connection(key)
-        # close current connection and do cleanup for session
-        yield session._deferred_logout()
+        if not session._clients:
+            # close current connection and do cleanup for session
+            yield session._deferred_logout()
         returnValue(None)
 
 


### PR DESCRIPTION
Fixes ZPS-2915

active connections were being closed before clients could finish.  also moved single commands back to the semaphore because of connection timing
be sure that we have a connection when sending a request.