### PR TITLE
updates for dealing with closing connections. also kerberos

### DIFF
--- a/txwinrm/SessionManager.py
+++ b/txwinrm/SessionManager.py
@@ -97,10 +97,6 @@ class Session(object):
         """Calls session._deferred_logout() only if all other clients
         using the same session have also called deferred_logout.
         """
-        # we still have clients running, don't logout
-        if self._logout_dc is not None and self._logout_dc.cancelled:
-            returnValue(None)
-
         if self._token:
             try:
                 # go ahead and clear the token
@@ -185,6 +181,7 @@ class SessionManager(object):
         if session is not None:
             try:
                 session._logout_dc.cancel()
+                session._logout_dc = None
             except Exception:
                 pass
             # add client to set
@@ -218,6 +215,7 @@ class SessionManager(object):
             return
         try:
             session._logout_dc.cancel()
+            session._logout_dc = None
         except Exception:
             pass
         session._clients.discard(client)
@@ -231,9 +229,7 @@ class SessionManager(object):
     def deferred_logout(self, key):
         # first, get the session from the key
         session = self.get_connection(key)
-        if session._logout_dc is None or not session._logout_dc.cancelled:
-            # close current connection and do cleanup for session
-            yield session._deferred_logout()
+        yield session._deferred_logout()
         returnValue(None)
 
 

--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -177,9 +177,14 @@ class WinRMSession(Session):
         # gssclient will no longer be valid so get rid of it
         # set token to None so the next client will reinitialize
         #   the connection
-        if self._clients:
+        if self._logout_dc is not None and self._logout_dc.cancelled:
             # one last check so that we don't kill an active client
             returnValue(None)
+        yield self._reset_all()
+
+    @inlineCallbacks
+    def _reset_all(self):
+        self._login_d = None
         if self._gssclient is not None:
             self._gssclient.cleanup()
             self._gssclient = None
@@ -187,6 +192,7 @@ class WinRMSession(Session):
         yield self.close_cached_connections()
         self._agent._pool = None
         self._agent = None
+        self._logout_dc = None
         returnValue(None)
 
     @inlineCallbacks
@@ -194,13 +200,8 @@ class WinRMSession(Session):
         if response.code == UNAUTHORIZED or response.code == BAD_REQUEST:
             # check to see if we need to re-authorize due to lost connection or bad request error
             # only retry if using kerberos
-            self._token = None
-            yield self.close_cached_connections()
-            self._login_d = None
-            if self._gssclient is not None:
-                self._gssclient.cleanup()
-                self._gssclient = None
-                self._token = None
+            yield self._reset_all()
+            if client.is_kerberos():
                 yield SESSION_MANAGER.init_connection(client, WinRMSession)
                 try:
                     yield self._set_headers()
@@ -270,12 +271,10 @@ class WinRMSession(Session):
     @inlineCallbacks
     def _send_request(self, request_template_name, client, envelope_size=None,
                       locale=None, code_page=None, **kwargs):
-        if self._logout_dc is not None:
-            try:
-                self._logout_dc.cancel()
-                self._logout_dc = None
-            except Exception:
-                pass
+        try:
+            self._logout_dc.cancel()
+        except Exception:
+            pass
         kwargs['envelope_size'] = envelope_size or client._conn_info.envelope_size
         kwargs['locale'] = locale or client._conn_info.locale
         kwargs['code_page'] = code_page or client._conn_info.code_page
@@ -340,6 +339,7 @@ class WinRMClient(object):
         return self._conn_info.auth_type == 'kerberos'
 
     def decrypt_body(self, body):
+        session = self.session()
         return self.session().decrypt_body(body)
 
     @inlineCallbacks
@@ -413,7 +413,6 @@ class SingleCommandClient(WinRMClient):
     """Client to send a single command to a winrm device"""
     def __init__(self, conn_info):
         super(SingleCommandClient, self).__init__(conn_info)
-        self.key = (self._conn_info.ipaddress, 'short')
 
     @inlineCallbacks
     def run_command(self, command_line, ps_script=None):
@@ -427,9 +426,15 @@ class SingleCommandClient(WinRMClient):
         """
         cmd_response = None
         self.ps_script = ps_script
+        if ps_script:
+            self.key = (self._conn_info.ipaddress, 'short', self.ps_script)
+        else:
+            self.key = (self._conn_info.ipaddress, 'short', command_line)
         yield self.init_connection()
         try:
-            cmd_response = yield self.session().semrun(self.run_single_command, command_line)
+            # cmd_response = yield self.session().semrun(self.run_single_command, command_line)
+            run_cmd_d = self.run_single_command(command_line)
+            cmd_response = yield add_timeout(run_cmd_d, self._conn_info.timeout)
         except Exception as e:
             if isinstance(e, TimeoutError):
                 yield self.close_cached_connections()


### PR DESCRIPTION
Fixes ZPS-2394, ZPS-2963

during modeling, we were obtaining spn tickets in parallel when trying to query wmi and powershell.  this is creating two tickets in the cache.  modeling was still working, but we really should only do this once.
the agent was not being reallocated for basic auth for a long running command so we need to make sure we get a new agent
also made it so that we consistently close a connection when attempting a retry or when we are finished with a connection
a better way to abort a close connection is to see if the deferred has been cancelled