### PR TITLE
Fix error handling from semaphore

### DIFF
--- a/txwinrm/SessionManager.py
+++ b/txwinrm/SessionManager.py
@@ -219,7 +219,7 @@ class SessionManager(object):
         except Exception:
             pass
         session._clients.discard(client)
-        timeout = DEFAULT_TIMEOUT
+        timeout = DEFAULT_TIMEOUT + 5
         if immediately:
             timeout = 0
         if not session._clients:


### PR DESCRIPTION
Fixes ZPS-3097

UnauthorizedError is a subclass of RequestError, so it was being caught by the first except.  let's just close up connections and raise the exception
Be sure we're connected and have an agent to send an enumerate request