### PR TITLE
reset headers and url in reset_all

### DIFF
--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -189,6 +189,8 @@ class WinRMSession(Session):
         yield self.close_cached_connections()
         self._agent._pool = None
         self._agent = None
+        self._headers = None
+        self._url = None
         returnValue(None)
 
     @inlineCallbacks


### PR DESCRIPTION
Fixes ZPS-2712

The headers were never updated with the new conn_info changes after a password change.  this will allow us to recreate the headers when correct settings are passed in