### PR TITLE
Revert removal of importing create_winrm_client

### DIFF
--- a/txwinrm/collect.py
+++ b/txwinrm/collect.py
@@ -11,7 +11,7 @@ import logging
 
 from collections import namedtuple
 from twisted.internet import defer
-from .enumerate import DEFAULT_RESOURCE_URI
+from .enumerate import create_winrm_client, DEFAULT_RESOURCE_URI
 from .WinRMClient import EnumerateClient
 from .util import (
     ConnectionInfo,


### PR DESCRIPTION
Fixes ZPS-3144

HyperV Zenpack relies on create_winrm_client being imported into collect