### PR TITLE
fix decrypt integrity check error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -239,6 +239,7 @@ The winrs program has four modes of operation:
    executes a list of commands (actually right now it executes one
    command twice as a proof-of-concept)
 -  powershell: Run a powershell script.  This is NOT interactive.
+   Only enter the script here, not the powershell command.
 
 
 An example of interactive mode

--- a/txwinrm/util.py
+++ b/txwinrm/util.py
@@ -447,7 +447,7 @@ def _authenticate_with_kerberos(conn_info, url, agent, gss_client=None):
             raise Exception(msg)
         raise UnauthorizedError(
             "Unauthorized to use winrm on {}. Must be Administrator or "
-            "user given permissions to use winrm.".format(
+            "user given permissions to use winrm".format(
                 conn_info.hostname))
     elif response.code == httplib.FORBIDDEN:
         raise ForbiddenError(


### PR DESCRIPTION
Fixes ZPS-5490

when handling a response, we were resetting the gssclient, or kerberos context, before we had a chance to decrypt the reponse message.  this decrypts the message first and will continue as it should.  also, no need to try and receive from a command that has already exited. updated the winrs command line utility also.