### PR TITLE
only init one connection at a time to allow multiple users

### DIFF
--- a/txwinrm/test/usertest.ini
+++ b/txwinrm/test/usertest.ini
@@ -15,3 +15,7 @@ server2.ipaddress = <ipaddress2>
 [kdc]
 
 kdc = <kdcaddress>
+
+[options]
+; set debug to True/true to see debug log
+debug = False

--- a/txwinrm/test/usertest.py
+++ b/txwinrm/test/usertest.py
@@ -73,8 +73,8 @@ class WinrmCollectClient(object):
             assert(conn_info.username.lower() == authGSSClientUserName(
                 client.session()._gssclient._context).lower())
         except Exception:
-            print 'Expected and Actual usernames do not match for host {}'\
-                .format(conn_info.hostname)
+            print 'ERROR: Expected and Actual usernames do not match for host'\
+                  ' {}'.format(conn_info.hostname)
             print 'Expected username: {}, Actual username {}'.format(
                 conn_info.username,
                 authGSSClientUserName(client.session()._gssclient._context))
@@ -92,6 +92,9 @@ def user_run():
     parser = RawConfigParser(allow_no_value=True)
     parser.read('./txwinrm/test/usertest.ini')
     setup = {}
+    debug = parser.get('options', 'debug')
+    if debug.lower() == 'true':
+        log.setLevel(level=logging.DEBUG)
     for k, v in parser.items('setup'):
         server, option = k.split('.')
         if server not in setup.keys():
@@ -122,7 +125,6 @@ def user_run():
 
 
 if __name__ == '__main__':
-    import logging
     from twisted.internet import reactor
     reactor.callWhenRunning(user_run)
     reactor.run()

--- a/txwinrm/twisted_utils.py
+++ b/txwinrm/twisted_utils.py
@@ -9,9 +9,14 @@
 
 from twisted.internet import defer, error, reactor
 from twisted.python import failure
+from twisted.web._newclient import ResponseNeverReceived
 
 
-def with_timeout(fn, args=None, kwargs=None, seconds=None, exception_class=error.TimeoutError):
+def with_timeout(fn,
+                 args=None,
+                 kwargs=None,
+                 seconds=None,
+                 exception_class=error.TimeoutError):
     """Execute asynchronous function fn(*args, **kwargs) with a timeout."""
     return add_timeout(
         deferred=fn(*args, **kwargs),
@@ -33,7 +38,17 @@ def add_timeout(deferred, seconds, exception_class=error.TimeoutError):
 
     def handle_result(result):
         is_failure = isinstance(result, failure.Failure)
-        is_cancelled = is_failure and isinstance(result.value, defer.CancelledError)
+        is_cancelled = is_failure and isinstance(result.value,
+                                                 defer.CancelledError)
+
+        # With twisted.web._newclient, errors may be wrapped in a
+        # 'ResponseNeverReceived', including CancelledError.  If it is,
+        # set is_cancelled.
+        if is_failure and isinstance(result.value, ResponseNeverReceived):
+            if any([isinstance(x, failure.Failure) and
+                    isinstance(x.value, defer.CancelledError)
+                    for x in result.value.reasons]):
+                is_cancelled = True
 
         if delayed_timeout.active():
             # Cancel the timeout since a result came before it fired.


### PR DESCRIPTION
Fixes ZPS-3564

the deferredSemaphore performing authGSSClientStep was executing too quickly and occasionally the wrong credential cache will be used. this will ensure that only one connection is created at a time and that the correct credentials will be used. also add in common check for ResponseNeverReceived so we don't error on cancels that we cause.