### PR TITLE
be sure conn_info has connect_timeout attribute

### DIFF
--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -702,11 +702,14 @@ class EnumerateClient(WinRMClient):
 
     @inlineCallbacks
     def do_collect(self, enum_infos):
-        """Run enumerations in the session's semaphore.  Windows must finish
-        an enumeration before a new command or enumeration can start
+        """Run enumerations in the session's semaphore.
+
+        Windows must finish an enumeration before a new
+        command or enumeration can start
         """
         items = {}
-        yield self.init_connection()
+        if not self.is_connected():
+            yield self.init_connection()
         for enum_info in enum_infos:
             try:
                 items[enum_info] = yield self.session().semrun(

--- a/txwinrm/util.py
+++ b/txwinrm/util.py
@@ -465,7 +465,7 @@ def _authenticate_with_kerberos(conn_info, url, agent, gss_client=None):
 
 
 def update_conn_info(old_conn_info, new_conn_info):
-    if old_conn_info is None:
+    if old_conn_info is None or not hasattr(old_conn_info, 'connect_timeout'):
         return(ConnectionInfo(hostname=new_conn_info.hostname,
                               auth_type=new_conn_info.auth_type,
                               username=new_conn_info.username,


### PR DESCRIPTION
fixes ZPS-5087

this can cause an error when connecting using a stale conn_info that does not have the connect_timeout attribute.  root cause for 'NoneType' has no attribute 'getConnection' seems to be an out of date kerberos.so module.