### PR TITLE
return an OK response, kerb context fixes

### DIFF
--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -381,8 +381,6 @@ class WinRMSession(Session):
             response = yield self._agent.request(
                 'POST', self._url, self._headers, body_producer)
         except Exception as e:
-            print '{} exception sending request: {}'.format(
-                self._conn_info.hostname, e)
             if isinstance(e, kerberos.GSSError) and 'The referenced '\
                     'context has expired' in e.args[0][0]:
                 # tried to use expired context, retry

--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -136,6 +136,15 @@ class WinRMSession(Session):
             seconds=self._conn_info.timeout)
 
     def is_kerberos(self):
+        """Check for kerberos connection.
+
+        use a lazy import. any kerberos reference in this module
+        will call this method first so there will be no AttributeErrors
+        for referencing the kerberos module without it being imported
+        """
+        global kerberos
+        if not kerberos:
+            import kerberos
         return self._conn_info.auth_type == 'kerberos'
 
     def decrypt_body(self, body):
@@ -158,6 +167,21 @@ class WinRMSession(Session):
         self._conn_info = update_conn_info(self._conn_info, client._conn_info)
 
     @inlineCallbacks
+    def run_authenticate(self):
+        # run through single semaphore so that we can allow
+        # for multiple users. gss uses KRB5CCNAME to determine
+        # cache to use, so we must make sure that the env variable
+        # is not overwritten.
+        self._token = self._gssclient = yield KRB5_SEM.run(
+            with_timeout,
+            fn=_authenticate_with_kerberos,
+            args=(self._conn_info,
+                  self._url,
+                  self._agent),
+            kwargs={},
+            seconds=self._conn_info.timeout)
+
+    @inlineCallbacks
     def _deferred_login(self, client=None):
         if self._agent is None:
             self._agent = _get_agent()
@@ -169,33 +193,13 @@ class WinRMSession(Session):
             c=self._conn_info)
         if self.is_kerberos():
             try:
-                # run through single semaphore so that we can allow
-                # for multiple users. gss uses KRB5CCNAME to determine
-                # cache to use, so we must make sure that the env variable
-                # is not overwritten.
-                self._token = self._gssclient = yield KRB5_SEM.run(
-                    with_timeout,
-                    fn=_authenticate_with_kerberos,
-                    args=(self._conn_info,
-                          self._url,
-                          self._agent),
-                    kwargs={},
-                    seconds=self._conn_info.timeout)
+                yield self.run_authenticate()
             except Exception as e:
-                global kerberos
-                import kerberos
                 if isinstance(e, kerberos.GSSError) and 'The referenced '\
                         'context has expired' in e.args[0][0]:
                     LOG.debug('found The referenced context has expired,'
                               ' starting over')
-                    self._token = self._gssclient = yield KRB5_SEM.run(
-                        with_timeout,
-                        fn=_authenticate_with_kerberos,
-                        args=(self._conn_info,
-                              self._url,
-                              self._agent),
-                        kwargs={},
-                        seconds=self._conn_info.timeout)
+                    yield self.run_authenticate()
                 else:
                     raise
             returnValue(self._gssclient)
@@ -278,7 +282,8 @@ class WinRMSession(Session):
                     "Unauthorized to use winrm on {}. Must be Administrator"
                     " or user given permissions to use winrm".format(
                         client._conn_info.hostname))
-            else:
+            elif response.code != OK:
+                # raise error on anything other than ok
                 raise RequestError("{}: HTTP status: {}. {}.".format(
                     client._conn_info.ipaddress, response.code, message))
         if response.code == FORBIDDEN:
@@ -307,58 +312,92 @@ class WinRMSession(Session):
         returnValue(ET.fromstring(xml_str))
 
     @inlineCallbacks
-    def _send_request(self, request_template_name, client, envelope_size=None,
-                      locale=None, code_page=None, **kwargs):
-        try:
-            self._logout_dc.cancel()
-            self._logout_dc = None
-        except Exception:
-            pass
+    def check_lifetime(self, client):
+        """Check to see if our ticket is going to expire soon."""
+        lifetime = self._gssclient.context_lifetime()
+        if lifetime <= self._lifetime_limit:
+            # go ahead and kill the connection
+            # defer until it does expire and reinit
+            d = Deferred()
+            yield self._reset_all()
+            try:
+                yield add_timeout(d, lifetime + 1)
+            except Exception:
+                pass
+            yield client.init_connection()
+        returnValue(None)
+
+    @inlineCallbacks
+    def wait_for_connection(self, client):
+        """Wait until connection established."""
         if self._login_d and not self._login_d.called:
             # check for a reconnection attempt so we do not send any requests
             # to a dead connection or try to check the context lifetime on an
             # unestablished connection
             self._token = yield self._login_d
-        if self._token is None:
-            # no login attempt occurred, so initiate connection
+        if self._token is None or (self.is_kerberos() and self._gssclient is None):
+            # no token or gssclient, if kerberos, so initiate connection
             yield client.init_connection()
-        if client.is_kerberos():
-            # lazy import
-            global kerberos
-            if not kerberos:
-                import kerberos
-            # check to see if our ticket is going to expire soon
-            # go ahead and kill the connection
-            # defer until it does expire and reinit
-            lifetime = self._gssclient.context_lifetime()
-            if lifetime <= self._lifetime_limit:
-                d = Deferred()
-                yield self._reset_all()
-                try:
-                    yield add_timeout(d, lifetime)
-                except Exception:
-                    pass
-                yield client.init_connection()
-        kwargs['envelope_size'] = envelope_size or self._conn_info.envelope_size
-        kwargs['locale'] = locale or self._conn_info.locale
-        kwargs['code_page'] = code_page or self._conn_info.code_page
-        LOG.debug('{} sending request: {} {}'.format(
-            self._conn_info.hostname, request_template_name, kwargs))
-        request = _get_request_template(request_template_name).format(**kwargs)
+        returnValue(None)
+
+    def prep_request(self, request_template_name, **kwargs):
+        """Prepare request and body_producer."""
+        request = _get_request_template(request_template_name).format(
+            **kwargs)
         self._headers = self._set_headers()
         if self.is_kerberos():
             encrypted_request = self._gssclient.encrypt_body(request)
             if not encrypted_request.startswith("--Encrypted Boundary"):
-                self._headers.setRawHeaders('Content-Type', _CONTENT_TYPE['Content-Type'])
+                self._headers.setRawHeaders(
+                    'Content-Type',
+                    _CONTENT_TYPE['Content-Type'])
             body_producer = _StringProducer(encrypted_request)
         else:
             body_producer = _StringProducer(request)
+        return request, body_producer
+
+    @inlineCallbacks
+    def _send_request(self, request_template_name, client, envelope_size=None,
+                      locale=None, code_page=None, **kwargs):
+        try:
+            # cancel logout attempt
+            self._logout_dc.cancel()
+            self._logout_dc = None
+        except Exception:
+            pass
+        yield self.wait_for_connection(client)
+        if client.is_kerberos():
+            yield self.check_lifetime(client)
+        kwargs['envelope_size'] = envelope_size or\
+            self._conn_info.envelope_size
+        kwargs['locale'] = locale or self._conn_info.locale
+        kwargs['code_page'] = code_page or self._conn_info.code_page
+        LOG.debug('{} sending request: {} {}'.format(
+            self._conn_info.hostname, request_template_name, kwargs))
+        request, body_producer = self.prep_request(
+            request_template_name,
+            **kwargs)
         try:
             response = yield self._agent.request(
                 'POST', self._url, self._headers, body_producer)
         except Exception as e:
-            LOG.debug('{} exception sending request: {}'.format(self._conn_info.hostname, e))
-            raise
+            print '{} exception sending request: {}'.format(
+                self._conn_info.hostname, e)
+            if isinstance(e, kerberos.GSSError) and 'The referenced '\
+                    'context has expired' in e.args[0][0]:
+                # tried to use expired context, retry
+                LOG.debug('found The referenced context has expired,'
+                          ' resetting connection and resending request')
+                yield self._reset_all()
+                response = yield self._send_request(
+                    request_template_name,
+                    client,
+                    envelope_size=envelope_size,
+                    **kwargs)
+            else:
+                LOG.debug('{} exception sending request: {}'.format(
+                    self._conn_info.hostname, e))
+                raise
         LOG.debug('{} received response {} {}'.format(
             self._conn_info.hostname, response.code, request_template_name))
         response = yield self.handle_response(request, response, client)
@@ -378,7 +417,13 @@ class WinRMClient(object):
         self._lifetime_limit = lifetime_limit
 
     def is_connected(self):
-        if self.session() and self.session()._agent:
+        session = self.session()
+        if session and session._agent and session._token:
+            if session.is_kerberos():
+                if session._gssclient:
+                    return True
+                else:
+                    return False
             return True
         else:
             return False

--- a/txwinrm/collect.py
+++ b/txwinrm/collect.py
@@ -8,17 +8,23 @@
 ##############################################################################
 
 import logging
+import time
 
 from collections import namedtuple
-from twisted.internet import defer
-from .enumerate import create_winrm_client, DEFAULT_RESOURCE_URI
-from .WinRMClient import EnumerateClient
+from twisted.internet import defer, reactor
+from .enumerate import (
+    DEFAULT_RESOURCE_URI,
+    SaxResponseHandler,
+    _MAX_REQUESTS_PER_ENUMERATION,
+)
+from .WinRMClient import EnumerateClient, WinRMClient
 from .util import (
     ConnectionInfo,
     ForbiddenError,
     RequestError,
     UnauthorizedError,
 )
+from .twisted_utils import add_timeout
 
 
 EnumInfo = namedtuple('EnumInfo', ['wql', 'resource_uri'])
@@ -29,7 +35,80 @@ def create_enum_info(wql, resource_uri=DEFAULT_RESOURCE_URI):
     return EnumInfo(wql, resource_uri)
 
 
-class WinrmCollectClient(object):
+def t_print(thing):
+    print '{}  {}'.format(time.strftime('%H:%M:%S'), thing)
+
+
+class WinrmCollectClient(WinRMClient):
+
+    def __init__(self, conn_info):
+        super(WinrmCollectClient, self).__init__(conn_info)
+        self._handler = SaxResponseHandler(self)
+        self._hostname = self._conn_info.ipaddress
+        self.key = (self._conn_info.ipaddress, 'enumerate')
+
+    @defer.inlineCallbacks
+    def test_context_lifetime(self, enum_infos):
+        """Test expired context handling.
+
+        we do not want to use an expiring context(spn). this test
+        will wait until there's less than 60s left for the conext lifetime
+        then set the limit to 60s, and allow the expiring mechanism in the
+        session handle the expiration and obtain a new connection.
+
+        for quicker testing, change the lifetime of the spn on windows
+        AD to be 10 minutes in group policy
+        """
+        t_print('init_connection')
+        yield self.init_connection()
+        while True:
+            lifetime = self.session()._gssclient.context_lifetime()
+            t_print('lifetime left: {}s'.format(lifetime))
+            self.session().set_lifetime_limit(60)
+            if lifetime <= 60:
+                break
+            t_print('kill connection')
+            yield self.session()._reset_all()
+            d = defer.Deferred()
+            try:
+                t_print('sleep 60 seconds')
+                yield add_timeout(d, 60)
+            except Exception:
+                pass
+            t_print('init connection')
+            yield self.init_connection()
+
+        t_print('_lifetime_limit: {}'.format(self.session()._lifetime_limit))
+        request_template_name = 'enumerate'
+        enumeration_context = None
+        items = []
+        for enum_info in enum_infos:
+            try:
+                for i in xrange(_MAX_REQUESTS_PER_ENUMERATION):
+                    log.debug('{0} "{1}" {2}'.format(
+                        self._hostname, enum_info.wql, request_template_name))
+                    response = yield self.session()._send_request(
+                        request_template_name,
+                        self,
+                        resource_uri=DEFAULT_RESOURCE_URI,
+                        wql=enum_info.wql,
+                        enumeration_context=enumeration_context)
+                    log.debug("{0} {1} HTTP status: {2}".format(
+                        self._hostname, enum_info.wql, response.code))
+                    enumeration_context, new_items = \
+                        yield self._handler.handle_response(response)
+                    items.extend(new_items)
+                    if not enumeration_context:
+                        break
+                    request_template_name = 'pull'
+                else:
+                    raise Exception("Reached max requests per enumeration.")
+            except Exception as e:
+                log.debug('{0} {1}'.format(self._hostname, e))
+                raise
+        lifetime = self.session()._gssclient.context_lifetime()
+        t_print('new connection lifetime left: {}s'.format(lifetime))
+        defer.returnValue(items)
 
     @defer.inlineCallbacks
     def do_collect(self, conn_info, enum_infos):
@@ -63,20 +142,31 @@ class WinrmCollectClient(object):
 if __name__ == '__main__':
     from pprint import pprint
     import logging
-    from twisted.internet import reactor
     logging.basicConfig()
-    winrm = WinrmCollectClient()
+    # log.setLevel(level=logging.DEBUG)
 
     @defer.inlineCallbacks
     def do_example_collect():
         connectiontype = 'Keep-Alive'
         conn_info = ConnectionInfo(
-            "10.30.50.34", "kerberos", "rbooth@SOLUTIONS.LOC", "", "http", 5985, connectiontype, "/home/zenoss/rbooth.keytab", '')
+            "",  # hostname
+            "kerberos",
+            "",  # domain user here
+            "",  # password here
+            "http",
+            5985,
+            connectiontype,
+            "",  # keytab unused
+            '',  # kdc
+            ipaddress='',  # ipaddress if no dns
+        )
+        winrm = WinrmCollectClient(conn_info)
         wql1 = create_enum_info(
             'Select Caption, DeviceID, Name From Win32_Processor')
         wql2 = create_enum_info(
             'select Name, Label, Capacity from Win32_Volume')
-        items = yield winrm.do_collect(conn_info, [wql1, wql2])
+        items = yield winrm.test_context_lifetime([wql1, wql2])
+        t_print('results')
         pprint(items)
         reactor.stop()
 


### PR DESCRIPTION
Fixes ZPS-5510

when we were retrying a request we were raising an error if it turned out to be ok. now we'll return the response data. other fixes around an expiring ticket and readability.  improved testing if session was connected.  created a test in collect.py to prove the expiration handling.  the test will defer until there's less than 60s left in the ticket lifetime, then allow the handler to wait for the ticket to expire and create a new connection