### PR TITLE
reset session variables before creating new connection

### DIFF
--- a/txwinrm/collect.py
+++ b/txwinrm/collect.py
@@ -68,7 +68,7 @@ class WinrmCollectClient(WinRMClient):
             if lifetime <= 60:
                 break
             t_print('kill connection')
-            yield self.session()._reset_all()
+            self.session().reset_all()
             d = defer.Deferred()
             try:
                 t_print('sleep 60 seconds')


### PR DESCRIPTION
Fixes ZPS-5323, ZPS-5557

because _reset_all() was yielding to the close_cached_connection() deferred, another request was able to sneak through and initiate a new connection. after the connections were closed, the agent was destroyed, which caused an error when we try to use the agent. by resetting everything and firing a deferred to close the connection, we can continue normally with a new session. found during testing that gssclient could have been reset before trying to encrypt the body, so we'll make sure we have a valid connection.