### PR TITLE
revert change to winrs single output

### DIFF
--- a/txwinrm/winrs.py
+++ b/txwinrm/winrs.py
@@ -94,7 +94,7 @@ class WinrsUtility(object):
         try:
             client = SingleCommandClient(args.conn_info)
             results = yield client.run_command(args.command)
-            print_output(results.stdout, results.stderr)
+            pprint(results)
         except Exception as e:
             LOG.error(e.message)
         finally:


### PR DESCRIPTION
fixes ZPS-5700

winrs single was always emitting full results in dictionary form. recent changes printed stdout/stderr as lines.  customer was depending on previous style of output