### PR TITLE
fix non-generator error with deferred logout

### DIFF
--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -17,7 +17,8 @@ from twisted.internet.defer import (
     inlineCallbacks,
     returnValue,
     DeferredSemaphore,
-    Deferred
+    Deferred,
+    succeed
 )
 from twisted.internet.error import TimeoutError
 
@@ -241,14 +242,13 @@ class WinRMSession(Session):
             yield agent._pool.closeCachedConnections()
         returnValue(None)
 
-    @inlineCallbacks
     def _deferred_logout(self):
         # close connections so they don't timeout
         # gssclient will no longer be valid so get rid of it
         # set token to None so the next client will reinitialize
         #   the connection
         self.reset_all()
-        returnValue(None)
+        yield succeed(None)
 
     @inlineCallbacks
     def _reset_all(self, gssclient, agent):


### PR DESCRIPTION
Fixes ZPS-5727

nothing was being yielded in WinRMSession._deferred_logout, so simply a returnValue was causing the traceback.  we'll now yield a success so that it is a generator again.

removed inlinecallbacks decorator