### PR TITLE
make use of credential cache collections

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -511,6 +511,10 @@ Run txwinrm/test/precommit before merging to master. This requires that you...
 Changes
 -------
 
+1.4.0
+* simplify connections to windows devices
+* allow for multiple users across domains by using credential cache collections
+
 1.2.2
 * Add support for multiple kdcs to be defined
 

--- a/txwinrm/krb5.py
+++ b/txwinrm/krb5.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2013, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2013-2019, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -85,6 +85,8 @@ class Config(object):
 
         # For further usage by kerberos python module.
         os.environ['KRB5_CONFIG'] = self.path
+        os.environ['KRB5CCNAME'] = 'DIR:{}'.format(
+            os.path.dirname(self.get_ccname('')))
 
     def add_includedir(self, includedir):
         self.includedirs.add(includedir)
@@ -282,6 +284,7 @@ class Config(object):
         except IOError as e:
             pass
 
+
 # Singleton. Loads from KRB5_CONFIG on import.
 config = Config()
 
@@ -341,7 +344,7 @@ def kinit(username, password, kdc, includedir=None, disable_rdns=False):
         config.add_includedir(includedir)
     config.add_kdc(realm, kdc, disable_rdns)
 
-    ccname = config.get_ccname(username)
+    ccname = config.get_ccname('')
     dirname = os.path.dirname(ccname)
     if not os.path.isdir(dirname):
         os.makedirs(dirname)
@@ -349,7 +352,7 @@ def kinit(username, password, kdc, includedir=None, disable_rdns=False):
     kinit_args = [kinit, '{}@{}'.format(user, realm)]
     kinit_env = {
         'KRB5_CONFIG': config.path,
-        'KRB5CCNAME': ccname,
+        'KRB5CCNAME': 'DIR:{}'.format(ccname),
     }
 
     protocol = KinitProcessProtocol(password)
@@ -366,6 +369,63 @@ def kinit(username, password, kdc, includedir=None, disable_rdns=False):
     except TypeError:
         # Everything's ok
         pass
+    defer.returnValue(results)
+
+
+class KlistProcessProtocol(ProcessProtocol):
+    """Communicates with klist command.
+    """
+
+    def __init__(self):
+        self.d = defer.Deferred()
+        self._data = ''
+        self._error = ''
+
+    def errReceived(self, data):
+        self._error += data
+
+    def outReceived(self, data):
+        self._data += data
+
+    def processEnded(self, reason):
+        self.d.callback(self._data if self._data else self._error)
+
+
+@defer.inlineCallbacks
+def klist(options=['-l']):
+    """Run klist with default -l option.
+
+    mainly used to check the credential cache collection(-l option).
+    can be used to run klist for other purposes by sending a list
+    of options.
+    """
+    klist = None
+    for path in ('/usr/bin/klist', '/usr/kerberos/bin/klist'):
+        if os.path.isfile(path):
+            klist = path
+            break
+
+    if not klist:
+        raise Exception("krb5-workstation is not installed")
+
+    global config
+
+    ccname = config.get_ccname('')
+    dirname = os.path.dirname(ccname)
+    if not os.path.isdir(dirname):
+        os.makedirs(dirname)
+
+    klist_args = [klist, ' '.join(options)]
+    klist_env = {
+        'KRB5_CONFIG': config.path,
+        'KRB5CCNAME': 'DIR:{}'.format(ccname),
+    }
+
+    protocol = KlistProcessProtocol()
+
+    reactor.spawnProcess(protocol, klist, klist_args, klist_env)
+
+    results = yield protocol.d
     defer.returnValue(results)
 
 


### PR DESCRIPTION
this will use the kerberos credential cache collections so that we do not need to specify a cache name and kerberos can easily switch between the different caches on it's own.