### PR TITLE
add ability to auto renew kerberos tickets

### DIFF
--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -99,7 +99,7 @@ def renew_ticket(conn_info):
                 conn_info.password,
                 conn_info.dcip,
                 renew=True)
-    RENEWALS.pop(conn_info.username)
+    RENEWALS.pop(conn_info.username.lower())
     returnValue(None)
 
 
@@ -439,14 +439,14 @@ class WinRMClient(object):
         connection = yield self.init_connection()
         if self.is_kerberos():
             connection = yield self.check_lifetime(connection)
-            if self._conn_info.username not in RENEWALS:
+            if self._conn_info.username.lower() not in RENEWALS:
                 timeout = connection._gssclient.context_lifetime()
                 if timeout < self._conn_info.renew_time:
                     timeout = 0
                 else:
                     timeout -= self._conn_info.renew_time
 
-                RENEWALS[self._conn_info.username] = reactor.callLater(
+                RENEWALS[self._conn_info.username.lower()] = reactor.callLater(
                     timeout, renew_ticket, self._conn_info)
         returnValue(connection)
 

--- a/txwinrm/WinRMClient.py
+++ b/txwinrm/WinRMClient.py
@@ -72,9 +72,12 @@ from .enumerate import (
 )
 from .SessionManager import SESSION_MANAGER, Session, copy
 from .twisted_utils import add_timeout, with_timeout
+from .krb5 import kinit
+
 kerberos = None
 LOG = logging.getLogger('winrm')
 KRB5_SEM = DeferredSemaphore(1)
+RENEWALS = {}
 
 
 class ShellException(Exception):
@@ -87,6 +90,17 @@ class ResponseError(Exception):
 
 class RetryRequest(Exception):
     pass
+
+
+@inlineCallbacks
+def renew_ticket(conn_info):
+    """Renew kerberos ticket preemptively."""
+    yield kinit(conn_info.username,
+                conn_info.password,
+                conn_info.dcip,
+                renew=True)
+    RENEWALS.pop(conn_info.username)
+    returnValue(None)
 
 
 def create_shell_from_elem(elem):
@@ -425,6 +439,15 @@ class WinRMClient(object):
         connection = yield self.init_connection()
         if self.is_kerberos():
             connection = yield self.check_lifetime(connection)
+            if self._conn_info.username not in RENEWALS:
+                timeout = connection._gssclient.context_lifetime()
+                if timeout < self._conn_info.renew_time:
+                    timeout = 0
+                else:
+                    timeout -= self._conn_info.renew_time
+
+                RENEWALS[self._conn_info.username] = reactor.callLater(
+                    timeout, renew_ticket, self._conn_info)
         returnValue(connection)
 
     @inlineCallbacks

--- a/txwinrm/krb5.py
+++ b/txwinrm/krb5.py
@@ -320,7 +320,8 @@ class KinitProcessProtocol(ProcessProtocol):
 
 
 @defer.inlineCallbacks
-def kinit(username, password, kdc, includedir=None, disable_rdns=False):
+def kinit(username, password, kdc, includedir=None,
+          disable_rdns=False, renew=False):
     """Perform kerberos initialization."""
     kinit = None
     for path in ('/usr/bin/kinit', '/usr/kerberos/bin/kinit'):
@@ -349,7 +350,10 @@ def kinit(username, password, kdc, includedir=None, disable_rdns=False):
     if not os.path.isdir(dirname):
         os.makedirs(dirname)
 
-    kinit_args = [kinit, '{}@{}'.format(user, realm)]
+    if renew:
+        kinit_args = [kinit, '-R', '{}@{}'.format(user, realm)]
+    else:
+        kinit_args = [kinit, '{}@{}'.format(user, realm)]
     kinit_env = {
         'KRB5_CONFIG': config.path,
         'KRB5CCNAME': 'DIR:{}'.format(ccname),


### PR DESCRIPTION
Fixes ZPS-5797

this will give the ability to automatically renew the kerberos user ticket so that we do not see an issue with attempting to use an expired context.  we will initiate a deferred that will fire 5 minutes (by default) before a ticket expires.  the first connection will add the one and only deferred per user and will call 'kinit -r user@DOMAIN'.  also found that using 'klist -l' may truncate the full user name.  we'll use 'klist -A' instead so that we can get the full user names for all caches.  added a simple test function in collect to make sure that user_in_klist is performing as expected.