### PR TITLE
revert using credential cache collection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -511,6 +511,9 @@ Run txwinrm/test/precommit before merging to master. This requires that you...
 Changes
 -------
 
+1.4.3
+* revert using credential cache collections due to limitation of only one user per domain
+
 1.4.0
 * simplify connections to windows devices
 * allow for multiple users across domains by using credential cache collections

--- a/txwinrm/collect.py
+++ b/txwinrm/collect.py
@@ -25,7 +25,6 @@ from .util import (
     UnauthorizedError,
 )
 from .twisted_utils import add_timeout
-from .krb5 import klist
 
 
 EnumInfo = namedtuple('EnumInfo', ['wql', 'resource_uri'])
@@ -135,24 +134,6 @@ class WinrmCollectClient(WinRMClient):
 
         defer.returnValue(items)
 
-    @defer.inlineCallbacks
-    def test_user_in_klist(self):
-        t_print('init_connection')
-        connection = yield self.connection()
-        results = 'Default principal: a@b'
-        t_print('user should not be found results:\n{}'.format(results))
-        if connection._gssclient.user_in_klist(results):
-            print 'found {} in klist results'.format(self._conn_info.username)
-        else:
-            print 'did not find {} in klist results'.format(self._conn_info.username)
-        results = yield klist(['-A'])
-        t_print('user should be found results:\n{}'.format(results))
-        if connection._gssclient.user_in_klist(results):
-            print 'found {} in klist results'.format(self._conn_info.username)
-        else:
-            print 'did not find {} in klist results'.format(self._conn_info.username)
-        defer.returnValue(None)
-
 # ----- An example of useage...
 
 
@@ -186,7 +167,6 @@ if __name__ == '__main__':
         items = []
         # items = yield winrm.test_context_lifetime([wql1, wql2])
         items = yield winrm.do_collect([wql1, wql2])
-        # yield winrm.test_user_in_klist()
         if items:
             t_print('results')
             pprint(items)

--- a/txwinrm/test/usertest.py
+++ b/txwinrm/test/usertest.py
@@ -71,13 +71,13 @@ class WinrmCollectClient(object):
 
         try:
             assert(conn_info.username.lower() == authGSSClientUserName(
-                client.session()._gssclient._context).lower())
+                client._connection._gssclient._context).lower())
         except Exception:
             print 'ERROR: Expected and Actual usernames do not match for host'\
                   ' {}'.format(conn_info.hostname)
             print 'Expected username: {}, Actual username {}'.format(
                 conn_info.username,
-                authGSSClientUserName(client.session()._gssclient._context))
+                authGSSClientUserName(client._connection._gssclient._context))
         else:
             print 'Expected and Actual usernames match for host {}: {}'\
                 .format(conn_info.hostname, conn_info.username)


### PR DESCRIPTION
credential cache collections only support one user per domain. insufficient for our needs so we need to use a semaphore to ensure we are using the correct cache name for a given user